### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ namespace Protocol
 	}
 }
 ```
-2. Server implemente ```IGreeter```.
+2. Server implements ```IGreeter```.
 ```csharp
 namespace Server
 {	
@@ -385,7 +385,7 @@ Sample/Standalone>dotnet new console
 	<ProjectReference Include="..\Server\Server.csproj" />
 </ItemGroup>
 ```
-2.  Create standlone service
+2.  Create standalone service
 ```csharp
 namespace Standalone
 {	


### PR DESCRIPTION
## Summary
- fix misspelling in server section
- correct typo in standalone service instructions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400e416988832ea9da17c9385578aa