### PR TITLE
Restore PinionCore.Utility submodule reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,12 @@ dotnet test [項目路徑].csproj
 
 #### 2. Protocol 生成機制
 ```csharp
-[PinionCore.Remote.Protocol.Creater]
+[PinionCore.Remote.Protocol.Creator]
 static partial void _Create(ref PinionCore.Remote.IProtocol protocol);
 ```
 - 使用 Source Generator 自動產生通訊協議
 - 必須定義在 static partial void 方法上
-- 透過 ProtocolCreater.Create() 取得 IProtocol 實例
+- 透過 ProtocolCreator.Create() 取得 IProtocol 實例
 
 #### 3. 連線抽象化
 - IStreamable: 客戶端資料流抽象

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,12 @@ dotnet test [項目路徑].csproj
 
 #### 2. Protocol 生成機制
 ```csharp
-[PinionCore.Remote.Protocol.Creater]
+[PinionCore.Remote.Protocol.Creator]
 static partial void _Create(ref PinionCore.Remote.IProtocol protocol);
 ```
 - 使用 Source Generator 自動產生通訊協議
 - 必須定義在 static partial void 方法上
-- 透過 ProtocolCreater.Create() 取得 IProtocol 實例
+- 透過 ProtocolCreator.Create() 取得 IProtocol 實例
 
 #### 3. 連線抽象化
 - IStreamable: 客戶端資料流抽象

--- a/PinionCore.Integration.Tests/Tests.cs
+++ b/PinionCore.Integration.Tests/Tests.cs
@@ -123,8 +123,8 @@ namespace PinionCore.Integration.Tests
 
             var test = new CType(1);
 
-            agentCommandRegister.Regist(typeof(IType), test);
-            agentCommandRegister.Unregist(test);
+            agentCommandRegister.Register(typeof(IType), test);
+            agentCommandRegister.Unregister(test);
 
             Assert.AreEqual(2, regCount);
             Assert.AreEqual(2, unregCount);

--- a/PinionCore.Network.Test/PackageTest.cs
+++ b/PinionCore.Network.Test/PackageTest.cs
@@ -182,8 +182,8 @@ namespace PinionCore.Network.Tests
             }
             var reader = new PinionCore.Network.PackageReader(new PinionCore.Network.ReverseStream(stream), PinionCore.Memorys.PoolProvider.Shared);
 
-            var readed = 0;
-            while (readed < buffers.Count)
+            var itemsRead = 0;
+            while (itemsRead < buffers.Count)
             {
                 var readBuffers = await reader.Read();
                 if (readBuffers.Count == 0)
@@ -193,13 +193,13 @@ namespace PinionCore.Network.Tests
                     NUnit.Framework.Assert.AreEqual(100, readBuffer.Bytes.Count);
                     for (var i = 0; i < 100; i++)
                     {
-                        NUnit.Framework.Assert.AreEqual((byte)(i + readed), readBuffer.Bytes.Array[readBuffer.Bytes.Offset + i]);
+                        NUnit.Framework.Assert.AreEqual((byte)(i + itemsRead), readBuffer.Bytes.Array[readBuffer.Bytes.Offset + i]);
                     }
-                    readed++;
+                    itemsRead++;
                 }
             }
 
-            NUnit.Framework.Assert.AreEqual(buffers.Count, readed);
+            NUnit.Framework.Assert.AreEqual(buffers.Count, itemsRead);
         }
     }
 }

--- a/PinionCore.Network/Tcp/Peer.cs
+++ b/PinionCore.Network/Tcp/Peer.cs
@@ -45,9 +45,9 @@ namespace PinionCore.Network.Tcp
             }
         }
 
-        IAwaitableSource<int> IStreamable.Receive(byte[] readed_byte, int offset, int count)
+        IAwaitableSource<int> IStreamable.Receive(byte[] buffer, int offset, int count)
         {
-            return _Receive.Transact(readed_byte, offset, count);
+            return _Receive.Transact(buffer, offset, count);
         }
         private int _EndReceive(IAsyncResult arg)
         {

--- a/PinionCore.Network/Tcp/SockerTransactor.cs
+++ b/PinionCore.Network/Tcp/SockerTransactor.cs
@@ -38,10 +38,10 @@ namespace PinionCore.Network.Tcp
         }
 
 
-        public IAwaitableSource<int> Transact(byte[] readed_byte, int offset, int count)
+        public IAwaitableSource<int> Transact(byte[] buffer, int offset, int count)
         {
             SocketError error;
-            IAsyncResult ar = _StartHandler(readed_byte, offset, count, SocketFlags.None, out error, _StartDone, null);
+            IAsyncResult ar = _StartHandler(buffer, offset, count, SocketFlags.None, out error, _StartDone, null);
 
             if (error != SocketError.Success && error != SocketError.IOPending)
             {

--- a/PinionCore.Remote.Client/AgentCommandBinder.cs
+++ b/PinionCore.Remote.Client/AgentCommandBinder.cs
@@ -28,10 +28,10 @@ namespace PinionCore.Remote.Client
             _Users.Add(user);
             foreach (Tuple<Type, object> g in user.Ghosts)
             {
-                _Register.Regist(g.Item1, g.Item2);
+                _Register.Register(g.Item1, g.Item2);
             }
-            rectifier.SupplyEvent += _Register.Regist;
-            rectifier.UnsupplyEvent += (type, obj) => { _Register.Unregist(obj); };
+            rectifier.SupplyEvent += _Register.Register;
+            rectifier.UnsupplyEvent += (type, obj) => { _Register.Unregister(obj); };
 
             return user.Id;
         }
@@ -42,7 +42,7 @@ namespace PinionCore.Remote.Client
                 return;
             foreach (Tuple<Type, object> g in user.Ghosts)
             {
-                _Register.Unregist(g.Item2);
+                _Register.Unregister(g.Item2);
             }
             _Users.RemoveAll(u => u.Id == id);
             user.Dispose();

--- a/PinionCore.Remote.Client/AgentCommandRegister.cs
+++ b/PinionCore.Remote.Client/AgentCommandRegister.cs
@@ -22,7 +22,7 @@ namespace PinionCore.Remote.Client
         }
 
 
-        public void Regist(Type type, object instance)
+        public void Register(Type type, object instance)
         {
 
             foreach (MethodInfo method in type.GetMethods())
@@ -42,7 +42,7 @@ namespace PinionCore.Remote.Client
 
 
 
-        public void Unregist(object instance)
+        public void Unregister(object instance)
         {
             AgentCommand[] removes = _Invokers.Where(i => i.Target == instance).ToArray();
             foreach (AgentCommand invoker in removes)

--- a/PinionCore.Remote.Gateway.Test/GatewaySessionConnectorTests.cs
+++ b/PinionCore.Remote.Gateway.Test/GatewaySessionConnectorTests.cs
@@ -28,11 +28,11 @@ namespace PinionCore.Remote.Gateway.Tests
             var bufs = readTask.Result;
             Assert.GreaterOrEqual(bufs.Count, 1);
 
-            var ser = new PinionCore.Remote.Gateway.Backends.Serializer(PinionCore.Memorys.PoolProvider.Shared);
+            var messageSerializer = new PinionCore.Remote.Gateway.Backends.Serializer(PinionCore.Memorys.PoolProvider.Shared);
             bool foundJoin = false;
             foreach (var b in bufs)
             {
-                var obj = ser.Deserialize(b);
+                var obj = messageSerializer.Deserialize(b);
                 var pkg = (PinionCore.Remote.Gateway.Backends.ClientToServerPackage)obj;
                 if (pkg.OpCode == PinionCore.Remote.Gateway.Backends.OpCodeClientToServer.Join && pkg.Id == id)
                 {
@@ -73,11 +73,11 @@ namespace PinionCore.Remote.Gateway.Tests
             var bufs = readTask.Result;
             Assert.GreaterOrEqual(bufs.Count, 1);
 
-            var ser = new PinionCore.Remote.Gateway.Backends.Serializer(PinionCore.Memorys.PoolProvider.Shared);
+            var messageSerializer = new PinionCore.Remote.Gateway.Backends.Serializer(PinionCore.Memorys.PoolProvider.Shared);
             bool foundLeave = false;
             foreach (var b in bufs)
             {
-                var obj = ser.Deserialize(b);
+                var obj = messageSerializer.Deserialize(b);
                 var pkg = (PinionCore.Remote.Gateway.Backends.ClientToServerPackage)obj;
                 if (pkg.OpCode == PinionCore.Remote.Gateway.Backends.OpCodeClientToServer.Leave && pkg.Id == id)
                 {

--- a/PinionCore.Remote.Standalone.Test/SoulTest.cs
+++ b/PinionCore.Remote.Standalone.Test/SoulTest.cs
@@ -32,8 +32,8 @@ namespace PinionCore.Remote.Standalone.Test
             IAgent agent = ghostAgent;
             IGpiA ghostGpia = null;
 
-            NSubstitute.Core.Events.DelegateEventWrapper<Action<IStreamable>> wapper = NSubstitute.Raise.Event<System.Action<IStreamable>>(serverStream);
-            listenable.StreamableEnterEvent += wapper;
+            NSubstitute.Core.Events.DelegateEventWrapper<Action<IStreamable>> wrapper = NSubstitute.Raise.Event<System.Action<IStreamable>>(serverStream);
+            listenable.StreamableEnterEvent += wrapper;
 
 
             agent.QueryNotifier<IGpiA>().Supply += gpi => ghostGpia = gpi;
@@ -45,7 +45,7 @@ namespace PinionCore.Remote.Standalone.Test
             }
             ghostAgent.Disable();
             agent.Disable();
-            listenable.StreamableLeaveEvent -= wapper;
+            listenable.StreamableLeaveEvent -= wrapper;
 
             IDisposable disposable = service;
             disposable.Dispose();

--- a/PinionCore.Remote.Tools.Protocol.Sources.IdentifyTestCommon/ProtocolProvider.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.IdentifyTestCommon/ProtocolProvider.cs
@@ -9,7 +9,7 @@
             return protocol;
         }
 
-        [Remote.Protocol.Creater]
+        [Remote.Protocol.Creator]
         static partial void _CreateCase1(ref PinionCore.Remote.IProtocol protocol);
 
 

--- a/PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests/OpCodeExchanger.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests/OpCodeExchanger.cs
@@ -9,17 +9,17 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests
         {
             Requests = new System.Collections.Generic.Queue<Tuple<ClientToServerOpCode, byte[]>>();
         }
-        public Action<ServerToClientOpCode, PinionCore.Memorys.Buffer> Responser;
+        public Action<ServerToClientOpCode, PinionCore.Memorys.Buffer> Responder;
         event Action<ServerToClientOpCode, PinionCore.Memorys.Buffer> Exchangeable<ClientToServerOpCode, ServerToClientOpCode>.ResponseEvent
         {
             add
             {
-                Responser += value;
+                Responder += value;
             }
 
             remove
             {
-                Responser -= value;
+                Responder -= value;
             }
         }
 

--- a/PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests/TestEnv.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests/TestEnv.cs
@@ -24,10 +24,9 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests
             _CounterPackage = Stopwatch.StartNew();
             Entry = entry;
             IProtocol protocol = PinionCore.Remote.Protocol.ProtocolProvider.Create(typeof(T2).Assembly).Single();
-            var ser = new PinionCore.Remote.Serializer(protocol.SerializeTypes);
-            var internalSer = new PinionCore.Remote.InternalSerializer();
+            var serializer = new PinionCore.Remote.Serializer(protocol.SerializeTypes);
             #region standalone
-            Service service = PinionCore.Remote.Standalone.Provider.CreateService(entry, protocol, ser, Memorys.PoolProvider.Shared);
+            Service service = PinionCore.Remote.Standalone.Provider.CreateService(entry, protocol, serializer, Memorys.PoolProvider.Shared);
 
 
             Ghost.IAgent agent = service.Create(new Stream());

--- a/PinionCore.Remote.Tools.Protocol.Sources.TestCommon/ProtocolProvider.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.TestCommon/ProtocolProvider.cs
@@ -9,7 +9,7 @@
             return protocol;
         }
 
-        [Remote.Protocol.Creater]
+        [Remote.Protocol.Creator]
         static partial void _CreateCase1(ref PinionCore.Remote.IProtocol protocol);
 
 
@@ -20,7 +20,7 @@
             return protocol;
         }
 
-        [Remote.Protocol.Creater]
+        [Remote.Protocol.Creator]
         static partial void _CreateCase2(ref IProtocol protocol);
     }
 }

--- a/PinionCore.Remote.Tools.Protocol.Sources.TestCommon/ProtocolProviderCase3.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.TestCommon/ProtocolProviderCase3.cs
@@ -9,6 +9,6 @@ public static partial class ProtocolProviderCase3
         return protocol;
     }
 
-    [PinionCore.Remote.Protocol.Creater]
+    [PinionCore.Remote.Protocol.Creator]
     static partial void _CreateCase3(ref IProtocol protocol);
 }

--- a/PinionCore.Remote.Tools.Protocol.Sources.Tests/GhostBuilderTests.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.Tests/GhostBuilderTests.cs
@@ -412,17 +412,17 @@ namespace NS1
 
             ModResult cnt = builder.ClassAndTypess.First();
             MethodDeclarationSyntax[] methods = cnt.GetSyntaxs<MethodDeclarationSyntax>().ToArray();
-            IndexerDeclarationSyntax[] indexs = cnt.GetSyntaxs<IndexerDeclarationSyntax>().ToArray();
+            IndexerDeclarationSyntax[] indexes = cnt.GetSyntaxs<IndexerDeclarationSyntax>().ToArray();
             EventDeclarationSyntax[] events = cnt.GetSyntaxs<EventDeclarationSyntax>().ToArray();
-            PropertyDeclarationSyntax[] propertys = cnt.GetSyntaxs<PropertyDeclarationSyntax>().ToArray();
+            PropertyDeclarationSyntax[] properties = cnt.GetSyntaxs<PropertyDeclarationSyntax>().ToArray();
             NUnit.Framework.Assert.AreEqual(1, methods.Count());
-            NUnit.Framework.Assert.AreEqual(2, indexs.Count());
+            NUnit.Framework.Assert.AreEqual(2, indexes.Count());
             NUnit.Framework.Assert.AreEqual(2, events.Count());
-            NUnit.Framework.Assert.AreEqual(3, propertys.Count());
+            NUnit.Framework.Assert.AreEqual(3, properties.Count());
 
 
             var dialogProvider = new DialogProvider();
-            Diagnostic[] dialogs = dialogProvider.Unsupports(builder.ClassAndTypess).ToArray();
+            Diagnostic[] dialogs = dialogProvider.UnsupportedMembers(builder.ClassAndTypess).ToArray();
             NUnit.Framework.Assert.AreEqual(8, dialogs.Count());
         }
 
@@ -558,7 +558,7 @@ namespace NS1
             return protocol;
         }
 
-        [PinionCore.Remote.Protocol.Creater]
+        [PinionCore.Remote.Protocol.Creator]
         static partial void _CreateCase1(ref PinionCore.Remote.IProtocol protocol);    
 }
 ";

--- a/PinionCore.Remote.Tools.Protocol.Sources.Tests/HelperExt.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.Tests/HelperExt.cs
@@ -15,7 +15,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.Tests
 
             IEnumerable<MetadataReference> references = new MetadataReference[]
             {
-                MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Protocol.CreaterAttribute).GetTypeInfo().Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Protocol.CreatorAttribute).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Value<>).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Property<>).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Notifier<>).GetTypeInfo().Assembly.Location),
@@ -34,9 +34,9 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.Tests
 
             return CSharpCompilation.Create(assemblyName, trees, references, new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary));
         }
-        public static CSharpCompilation Compilate(params SyntaxTree[] trees)
+        public static CSharpCompilation Compile(params SyntaxTree[] trees)
         {
-            return Compile(trees);
+            return Compile((IEnumerable<SyntaxTree>)trees);
         }
 
         public static CSharpCompilation Compilation(this SyntaxTree tree)
@@ -45,7 +45,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.Tests
 
             IEnumerable<MetadataReference> references = new MetadataReference[]
             {
-                MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Protocol.CreaterAttribute).GetTypeInfo().Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Protocol.CreatorAttribute).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Value<>).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Property<>).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(PinionCore.Remote.Notifier<>).GetTypeInfo().Assembly.Location),

--- a/PinionCore.Remote.Tools.Protocol.Sources.Tests/MemberIdProiderTests.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.Tests/MemberIdProiderTests.cs
@@ -191,16 +191,16 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.TestCommon
 
             InterfaceInheritor[] interfaceInheritors = gpis.Select(g => new InterfaceInheritor(g)).ToArray();
 
-            var classs = new System.Collections.Generic.List<ClassDeclarationSyntax>();
+            var classes = new System.Collections.Generic.List<ClassDeclarationSyntax>();
             foreach (InterfaceInheritor interfaceInheritor in interfaceInheritors)
             {
                 ClassDeclarationSyntax type = SyntaxFactory.ClassDeclaration(interfaceInheritor.Base.Identifier.Text + "Impl");
                 type = interfaceInheritor.Inherite(type);
-                classs.Add(type);
+                classes.Add(type);
             }
 
             var eventIdCount = new Dictionary<int, int>();
-            IEnumerable<EventDeclarationSyntax> classEvents = classs.SelectMany(c => c.DescendantNodes().OfType<EventDeclarationSyntax>());
+            IEnumerable<EventDeclarationSyntax> classEvents = classes.SelectMany(c => c.DescendantNodes().OfType<EventDeclarationSyntax>());
             foreach (EventDeclarationSyntax classEvent in classEvents)
             {
                 var id = memberIdProvider.DisrbutionIdWithGhost(classEvent);

--- a/PinionCore.Remote.Tools.Protocol.Sources.Tests/SyntaxModifierTests.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources.Tests/SyntaxModifierTests.cs
@@ -491,7 +491,7 @@ interface IA {
         }
 
         [Test]
-        public void CreatePinionCoreRemoteIEventProxyCreater()
+        public void CreatePinionCoreRemoteIEventProxyCreator()
         {
             var source = @"
 
@@ -505,13 +505,13 @@ class CIA : NS1.IA {
 ";
             SyntaxTree tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
             EventDeclarationSyntax efd = tree.GetRoot().DescendantNodes().OfType<EventDeclarationSyntax>().Single();
-            ClassDeclarationSyntax cefd = efd.CreatePinionCoreRemoteIEventProxyCreater();
+            ClassDeclarationSyntax cefd = efd.CreatePinionCoreRemoteIEventProxyCreator();
             NUnit.Framework.Assert.AreEqual("CNS1_IA_Event1", cefd.Identifier.ValueText);
 
         }
 
         [Test]
-        public void CreatePinionCoreRemoteIEventProxyCreaterNoTypes()
+        public void CreatePinionCoreRemoteIEventProxyCreatorNoTypes()
         {
             var source = @"
 class CIA : NS1.IA {
@@ -524,7 +524,7 @@ class CIA : NS1.IA {
 ";
             SyntaxTree tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(source);
             EventDeclarationSyntax efd = tree.GetRoot().DescendantNodes().OfType<EventDeclarationSyntax>().Single();
-            ClassDeclarationSyntax cefd = efd.CreatePinionCoreRemoteIEventProxyCreater();
+            ClassDeclarationSyntax cefd = efd.CreatePinionCoreRemoteIEventProxyCreator();
             NUnit.Framework.Assert.AreEqual("CNS1_IA_Event1", cefd.Identifier.ValueText);
 
         }

--- a/PinionCore.Remote.Tools.Protocol.Sources/DialogProvider.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/DialogProvider.cs
@@ -12,7 +12,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
         public static readonly DiagnosticDescriptor ExceptionDescriptor = new DiagnosticDescriptor("RRSE1", "Error", "unknown error:{0}", "Execute", DiagnosticSeverity.Error, false, null, "https://github.com/jiowchern/PinionCore.Remote/wiki/RRSE1");
 
-        public static readonly DiagnosticDescriptor UnsupportDescriptor = new DiagnosticDescriptor("RRSW1", "Warning", "Unsupport({0}):{1}", "Execute", DiagnosticSeverity.Warning, false, null, "https://github.com/jiowchern/PinionCore.Remote/wiki/RRSW1");
+        public static readonly DiagnosticDescriptor UnsupportedDescriptor = new DiagnosticDescriptor("RRSW1", "Warning", "Unsupported({0}):{1}", "Execute", DiagnosticSeverity.Warning, false, null, "https://github.com/jiowchern/PinionCore.Remote/wiki/RRSW1");
         public static readonly DiagnosticDescriptor MissingReferenceDescriptor = new DiagnosticDescriptor("RRSW2", "Warning", "Missing essentialt type :{0}", "Execute", DiagnosticSeverity.Warning, false, null, "https://github.com/jiowchern/PinionCore.Remote/wiki/RRSW2");
         public DialogProvider()
         {
@@ -22,30 +22,30 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
         }
 
-        internal System.Collections.Generic.IEnumerable<Diagnostic> Unsupports(IEnumerable<ModResult> classAndTypess)
+        internal System.Collections.Generic.IEnumerable<Diagnostic> UnsupportedMembers(IEnumerable<ModResult> classAndTypess)
         {
             foreach (ModResult cnt in classAndTypess)
             {
                 MethodDeclarationSyntax[] methods = cnt.GetSyntaxs<MethodDeclarationSyntax>().ToArray();
-                IndexerDeclarationSyntax[] indexs = cnt.GetSyntaxs<IndexerDeclarationSyntax>().ToArray();
+                IndexerDeclarationSyntax[] indexes = cnt.GetSyntaxs<IndexerDeclarationSyntax>().ToArray();
                 EventDeclarationSyntax[] events = cnt.GetSyntaxs<EventDeclarationSyntax>().ToArray();
-                PropertyDeclarationSyntax[] propertys = cnt.GetSyntaxs<PropertyDeclarationSyntax>().ToArray();
+                PropertyDeclarationSyntax[] properties = cnt.GetSyntaxs<PropertyDeclarationSyntax>().ToArray();
 
-                foreach (IndexerDeclarationSyntax item in indexs)
+                foreach (IndexerDeclarationSyntax item in indexes)
                 {
-                    yield return _Unsupport(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "index");
+                    yield return _Unsupported(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "index");
                 }
                 foreach (MethodDeclarationSyntax item in methods)
                 {
-                    yield return _Unsupport(item.WithBody(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Block()), "method");
+                    yield return _Unsupported(item.WithBody(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Block()), "method");
                 }
                 foreach (EventDeclarationSyntax item in events)
                 {
-                    yield return _Unsupport(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "event");
+                    yield return _Unsupported(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "event");
                 }
-                foreach (PropertyDeclarationSyntax item in propertys)
+                foreach (PropertyDeclarationSyntax item in properties)
                 {
-                    yield return _Unsupport(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "property");
+                    yield return _Unsupported(item.WithAccessorList(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AccessorList()), "property");
                 }
 
 
@@ -53,9 +53,9 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
         }
 
-        private Diagnostic _Unsupport(SyntaxNode node, string type)
+        private Diagnostic _Unsupported(SyntaxNode node, string type)
         {
-            return Diagnostic.Create(UnsupportDescriptor, Location.None, type, node.NormalizeWhitespace().ToFullString());
+            return Diagnostic.Create(UnsupportedDescriptor, Location.None, type, node.NormalizeWhitespace().ToFullString());
         }
 
         public Diagnostic Exception(string msg)

--- a/PinionCore.Remote.Tools.Protocol.Sources/EssentialReference.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/EssentialReference.cs
@@ -6,7 +6,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 {
     public class EssentialReference
     {
-        public readonly INamedTypeSymbol PinionCoreRemoteProtocolCreaterAttribute;
+        public readonly INamedTypeSymbol PinionCoreRemoteProtocolCreatorAttribute;
         public readonly INamedTypeSymbol PinionCoreRemoteProperty;
         public readonly INamedTypeSymbol PinionCoreRemoteNotifier;
         public readonly INamedTypeSymbol PinionCoreRemoteValue1;
@@ -22,7 +22,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
             this.Compilation = compilation;
 
-            PinionCoreRemoteProtocolCreaterAttribute = _GetType("PinionCore.Remote.Protocol.CreaterAttribute");
+            PinionCoreRemoteProtocolCreatorAttribute = _GetType("PinionCore.Remote.Protocol.CreatorAttribute");
             PinionCoreRemoteProperty = _GetType("PinionCore.Remote.Property`1");
             PinionCoreRemoteNotifier = _GetType("PinionCore.Remote.Notifier`1");
             PinionCoreRemoteValue1 = _GetType("PinionCore.Remote.Value`1");

--- a/PinionCore.Remote.Tools.Protocol.Sources/EventDeclarationSyntaxExtensions.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/EventDeclarationSyntaxExtensions.cs
@@ -7,7 +7,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
     public static class EventDeclarationSyntaxExtensions
     {
-        public static ClassDeclarationSyntax CreatePinionCoreRemoteIEventProxyCreater(this EventDeclarationSyntax eds)
+        public static ClassDeclarationSyntax CreatePinionCoreRemoteIEventProxyCreator(this EventDeclarationSyntax eds)
         {
 
             var een = eds.ExplicitInterfaceSpecifier.Name.ToString().Replace('.', '_');
@@ -20,7 +20,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                                 IdentifierName("PinionCore"),
                                 IdentifierName("Remote")
                             ),
-                            IdentifierName("IEventProxyCreater")
+                            IdentifierName("IEventProxyCreator")
                         );
 
             ParameterListSyntax paramList = SyntaxFactory.ParameterList();
@@ -50,7 +50,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
             var source = $@"
             
-            class {className} : PinionCore.Remote.IEventProxyCreater
+            class {className} : PinionCore.Remote.IEventProxyCreator
                 {{
             
                     System.Type _Type;
@@ -62,19 +62,19 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                         _Type = typeof({typeName});                   
                     
                     }}
-                    System.Delegate PinionCore.Remote.IEventProxyCreater.Create(long soul_id,int event_id,long handler_id, PinionCore.Remote.InvokeEventCallabck invoke_Event)
+                    System.Delegate PinionCore.Remote.IEventProxyCreator.Create(long soul_id,int event_id,long handler_id, PinionCore.Remote.InvokeEventCallabck invoke_Event)
                     {{                
                         var closure = new PinionCore.Remote.GenericEventClosure(soul_id , event_id ,handler_id, invoke_Event);                
                         return new System.Action{typesExpression}(({paramExpression}) => closure.Run(new object[]{{{paramExpression}}}));
                     }}
                 
             
-                    System.Type PinionCore.Remote.IEventProxyCreater.GetType()
+                    System.Type PinionCore.Remote.IEventProxyCreator.GetType()
                     {{
                         return _Type;
                     }}            
             
-                    string PinionCore.Remote.IEventProxyCreater.GetName()
+                    string PinionCore.Remote.IEventProxyCreator.GetName()
                     {{
                         return _Name;
                     }}            

--- a/PinionCore.Remote.Tools.Protocol.Sources/GhostBuilder.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/GhostBuilder.cs
@@ -71,7 +71,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                     type = builder.Inherite(type);
                 }
 
-                eventProxys.AddRange(type.DescendantNodes().OfType<EventDeclarationSyntax>().Select(e => e.CreatePinionCoreRemoteIEventProxyCreater()));
+                eventProxys.AddRange(type.DescendantNodes().OfType<EventDeclarationSyntax>().Select(e => e.CreatePinionCoreRemoteIEventProxyCreator()));
 
                 ModResult modResult = modifier.Mod(type);
                 classAndTypess.Add(modResult);

--- a/PinionCore.Remote.Tools.Protocol.Sources/MemberMapCodeBuilder.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/MemberMapCodeBuilder.cs
@@ -39,11 +39,11 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
             MethodInfosCode = string.Join(",", methods);*/
 
-            IEnumerable<string> propertys = from interfaceSyntax in _interfaces
-                                            from propertySyntax in interfaceSyntax.DescendantNodes().OfType<PropertyDeclarationSyntax>()
-                                            select _BuildCode(interfaceSyntax, propertySyntax);
+            IEnumerable<string> properties = from interfaceSyntax in _interfaces
+                                             from propertySyntax in interfaceSyntax.DescendantNodes().OfType<PropertyDeclarationSyntax>()
+                                             select _BuildCode(interfaceSyntax, propertySyntax);
 
-            PropertyInfosCode = string.Join(",", propertys);
+            PropertyInfosCode = string.Join(",", properties);
 
 
             IEnumerable<string> interfaces =

--- a/PinionCore.Remote.Tools.Protocol.Sources/ProtocoProviderlBuilder.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/ProtocoProviderlBuilder.cs
@@ -32,7 +32,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                             continue;
 
                         var name = info.Symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                        if (name != "global::PinionCore.Remote.Protocol.CreaterAttribute")
+                        if (name != "global::PinionCore.Remote.Protocol.CreatorAttribute")
                         {
                             continue;
                         }

--- a/PinionCore.Remote.Tools.Protocol.Sources/ProtocolBuilder.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/ProtocolBuilder.cs
@@ -40,7 +40,7 @@ public class {protocolName} : PinionCore.Remote.IProtocol
        
         _InterfaceProvider = new PinionCore.Remote.InterfaceProvider(new Dictionary<Type, Type> (){{ {interface_provider_code_builder.Code}}});
    
-        _EventProvider = new PinionCore.Remote.EventProvider( new IEventProxyCreater[]{{ {event_provider_code_builder.Code} }});        
+        _EventProvider = new PinionCore.Remote.EventProvider( new IEventProxyCreator[]{{ {event_provider_code_builder.Code} }});        
         _SerializeTypes = new System.Type[] {{{serCode}}};
         _MemberMap = new PinionCore.Remote.MemberMap(
             new System.Collections.Generic.Dictionary<int,System.Reflection.MethodInfo> {{{membermap_code_builder.MethodInfosCode}}} ,

--- a/PinionCore.Remote.Tools.Protocol.Sources/SourceGenerator.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/SourceGenerator.cs
@@ -23,7 +23,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
                 System.Collections.Generic.IEnumerable<SyntaxTree> sources = psb.Sources;
 
-                foreach (Diagnostic item in logger.Unsupports(psb.ClassAndTypess))
+                foreach (Diagnostic item in logger.UnsupportedMembers(psb.ClassAndTypess))
                 {
                     context.ReportDiagnostic(item);
                 }

--- a/PinionCore.Remote.Tools.Protocol.Sources/SyntaxExtensions.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/SyntaxExtensions.cs
@@ -129,10 +129,10 @@ namespace PinionCore.Remote.Tools.Protocol.Sources.Extensions
 
             SeparatedSyntaxList<VariableDeclaratorSyntax> vars = default;
             vars = vars.Add(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(event_symbol.Name)));
-            VariableDeclarationSyntax varibable = SyntaxFactory.VariableDeclaration(type, vars);
+            VariableDeclarationSyntax variable = SyntaxFactory.VariableDeclaration(type, vars);
 
 
-            EventFieldDeclarationSyntax member = SyntaxFactory.EventFieldDeclaration(varibable);
+            EventFieldDeclarationSyntax member = SyntaxFactory.EventFieldDeclaration(variable);
 
             return member;
 

--- a/PinionCore.Remote.Tools.Protocol.Sources/SyntaxModifier.cs
+++ b/PinionCore.Remote.Tools.Protocol.Sources/SyntaxModifier.cs
@@ -62,7 +62,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
 
             type = _ModifyMethodParameters(type, methods);
 
-            var propertys = new System.Collections.Generic.HashSet<PropertyDeclarationSyntax>(SyntaxNodeComparer.Default);
+            var properties = new System.Collections.Generic.HashSet<PropertyDeclarationSyntax>(SyntaxNodeComparer.Default);
             var events = new System.Collections.Generic.HashSet<EventDeclarationSyntax>(SyntaxNodeComparer.Default);
             var typesOfSerialization = new System.Collections.Generic.HashSet<TypeSyntax>(SyntaxNodeComparer.Default);
 
@@ -107,7 +107,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                 BlockModifiers.PropertyAndBlock prrb = _PropertyPinionCoreRemoteBlock.Mod(nodes);
                 if (prrb != null)
                 {
-                    propertys.Add(prrb.Property);
+                    properties.Add(prrb.Property);
                     replaceBlocks.Add(block, prrb.Block);
                     continue;
                 }
@@ -132,7 +132,7 @@ namespace PinionCore.Remote.Tools.Protocol.Sources
                 typesOfSerialization.AddRange(efds.Types);
             }
 
-            System.Collections.Generic.HashSet<PropertyDeclarationSyntax> propertyDeclarationSyntaxes = propertys;
+            System.Collections.Generic.HashSet<PropertyDeclarationSyntax> propertyDeclarationSyntaxes = properties;
 
             foreach (PropertyDeclarationSyntax pds in propertyDeclarationSyntaxes)
             {

--- a/PinionCore.Remote/CreatorAttribute.cs
+++ b/PinionCore.Remote/CreatorAttribute.cs
@@ -2,7 +2,7 @@
 {
     [System.AttributeUsage(System.AttributeTargets.Method)]
 
-    public class CreaterAttribute : System.Attribute
+    public class CreatorAttribute : System.Attribute
     {
 
     }

--- a/PinionCore.Remote/EventProvider.cs
+++ b/PinionCore.Remote/EventProvider.cs
@@ -9,23 +9,23 @@ namespace PinionCore.Remote
 {
     public class EventProvider
     {
-        private readonly IEventProxyCreater[] _ProxyCreaters;
+        private readonly IEventProxyCreator[] _ProxyCreators;
 
-        public EventProvider(IEnumerable<IEventProxyCreater> closures)
+        public EventProvider(IEnumerable<IEventProxyCreator> closures)
         {
-            _ProxyCreaters = closures.ToArray();
+            _ProxyCreators = closures.ToArray();
         }
 
 
-        private IEventProxyCreater _Find(EventInfo info)
+        private IEventProxyCreator _Find(EventInfo info)
         {
-            return (from closure in _ProxyCreaters
+            return (from closure in _ProxyCreators
                     where closure.GetType() == info.DeclaringType && closure.GetName() == info.Name
                     select closure).FirstOrDefault();
         }
 
 
-        public IEventProxyCreater Find(EventInfo info)
+        public IEventProxyCreator Find(EventInfo info)
         {
             return _Find(info);
 

--- a/PinionCore.Remote/GhostProviderQueryer.cs
+++ b/PinionCore.Remote/GhostProviderQueryer.cs
@@ -9,7 +9,7 @@ namespace PinionCore.Remote
         private readonly GhostsReturnValueHandler _ReturnValueHandler;
         private readonly GhostsOwner _GhostsOwner;
         private readonly GhostsHandler _GhostManager;
-        private readonly GhostsResponer _GhostsResponser;
+        private readonly GhostsResponder _GhostsResponder;
         private readonly ClientExchangeable[] ClientExchangeables;
         readonly System.Collections.Concurrent.ConcurrentQueue<Tuple<ServerToClientOpCode, PinionCore.Memorys.Buffer>> _Tuples;
 
@@ -22,8 +22,8 @@ namespace PinionCore.Remote
         }
         public event Action<byte[], byte[]> VersionCodeErrorEvent
         {
-            add { _GhostsResponser.VersionCodeErrorEvent += value; }
-            remove { _GhostsResponser.VersionCodeErrorEvent -= value; }
+            add { _GhostsResponder.VersionCodeErrorEvent += value; }
+            remove { _GhostsResponder.VersionCodeErrorEvent -= value; }
         }
         public GhostProviderQueryer(
             IProtocol protocol,
@@ -38,7 +38,7 @@ namespace PinionCore.Remote
             _GhostsOwner = ghosts_owner;
             _GhostManager = new GhostsHandler(protocol, serializer, internalSerializer, _GhostsOwner, _ReturnValueHandler);
 
-            _GhostsResponser = new GhostsResponer(internalSerializer, _GhostManager, _ReturnValueHandler, _PingHandler, _GhostsOwner, protocol);
+            _GhostsResponder = new GhostsResponder(internalSerializer, _GhostManager, _ReturnValueHandler, _PingHandler, _GhostsOwner, protocol);
 
             ClientExchangeables = new ClientExchangeable[]
             {
@@ -86,8 +86,8 @@ namespace PinionCore.Remote
                 {
                     exchangeable.Request(code, args);
                 }
-                _GhostsResponser.OnResponse(code, args);
-            }
+                _GhostsResponder.OnResponse(code, args);
+        }
         }
         public void Stop()
         {

--- a/PinionCore.Remote/GhostsResponder.cs
+++ b/PinionCore.Remote/GhostsResponder.cs
@@ -1,10 +1,10 @@
-﻿using PinionCore.Remote.Packages;
+using PinionCore.Remote.Packages;
 
 namespace PinionCore.Remote
 {
     namespace ProviderHelper
     {
-        public class GhostsResponer
+        public class GhostsResponder
         {
             private readonly IInternalSerializable _InternalSerializer;
             private readonly GhostsHandler _GhostHandler;
@@ -13,7 +13,7 @@ namespace PinionCore.Remote
             private readonly GhostsOwner _ProviderManager;
             private readonly IProtocol _Protocol;
 
-            public GhostsResponer(
+            public GhostsResponder(
                 IInternalSerializable internalSerializer,
                 GhostsHandler ghost_handler,
                 GhostsReturnValueHandler returnValueHandler,

--- a/PinionCore.Remote/IEventProxyCreator.cs
+++ b/PinionCore.Remote/IEventProxyCreator.cs
@@ -2,7 +2,7 @@
 
 namespace PinionCore.Remote
 {
-    public interface IEventProxyCreater
+    public interface IEventProxyCreator
     {
 
 

--- a/PinionCore.Remote/MemberMap.cs
+++ b/PinionCore.Remote/MemberMap.cs
@@ -11,31 +11,31 @@ namespace PinionCore.Remote
 
         private readonly Dictionary<int, MethodInfo> _Methods;
         private readonly Dictionary<int, EventInfo> _Events;
-        private readonly BilateralMap<int, PropertyInfo> _Propertys;
+        private readonly BilateralMap<int, PropertyInfo> _Properties;
         private readonly BilateralMap<int, Type> _Interfaces;
         private readonly Dictionary<Type, Func<IProvider>> _Providers;
 
-        public readonly IReadOnlyBilateralMap<int, PropertyInfo> Propertys;
+        public readonly IReadOnlyBilateralMap<int, PropertyInfo> Properties;
 
 
         public MemberMap(
             System.Collections.Generic.Dictionary<int,MethodInfo> methods,
             System.Collections.Generic.Dictionary<int, EventInfo> events,
-            IEnumerable<PropertyInfo> propertys,
+            IEnumerable<PropertyInfo> properties,
             IEnumerable<System.Tuple<System.Type, System.Func<PinionCore.Remote.IProvider>>> interfaces)
         {
             //_Events = new Dictionary<int, EventInfo> { { 0, typeof(MemberMap).GetEvent("") } };
             _Providers = new Dictionary<Type, Func<IProvider>>();
             _Methods = methods;
             _Events = events;
-            _Propertys = new BilateralMap<int, PropertyInfo>();
+            _Properties = new BilateralMap<int, PropertyInfo>();
             _Interfaces = new BilateralMap<int, Type>();
 
             var id = 0;
-            foreach (PropertyInfo propertyInfo in propertys)
+            foreach (PropertyInfo propertyInfo in properties)
             {
 
-                _Propertys.Add(++id, propertyInfo);
+                _Properties.Add(++id, propertyInfo);
             }
 
             id = 0;
@@ -46,7 +46,7 @@ namespace PinionCore.Remote
             }
 
 
-            Propertys = _Propertys;
+            Properties = _Properties;
         }
 
         public IProvider CreateProvider(Type type)
@@ -78,14 +78,14 @@ namespace PinionCore.Remote
         public int GetProperty(PropertyInfo info)
         {
             var id = 0;
-            _Propertys.TryGetItem1(info, out id);
+            _Properties.TryGetItem1(info, out id);
             return id;
         }
 
         public PropertyInfo GetProperty(int id)
         {
             PropertyInfo info;
-            _Propertys.TryGetItem2(id, out info);
+            _Properties.TryGetItem2(id, out info);
             return info;
         }
 

--- a/PinionCore.Remote/NotifierUpdater.cs
+++ b/PinionCore.Remote/NotifierUpdater.cs
@@ -25,7 +25,7 @@ namespace PinionCore.Remote
             _Notifiable.UnsupplyEvent += _Destroy;
         }
 
-        internal void Finial()
+        internal void Final()
         {
             _Notifiable.SupplyEvent -= _Create;
             _Notifiable.UnsupplyEvent -= _Destroy;

--- a/PinionCore.Remote/SoulBindHandler.cs
+++ b/PinionCore.Remote/SoulBindHandler.cs
@@ -63,7 +63,7 @@ namespace PinionCore.Remote
             _LoadSoul(newSoul.InterfaceId, newSoul.Id, returnType);
             _LoadProperty(newSoul);
             _LoadSoulCompile(newSoul.InterfaceId, newSoul.Id, returnId);
-            newSoul.Initial(_Protocol.GetMemberMap().Propertys.Item1s);
+            newSoul.Initial(_Protocol.GetMemberMap().Properties.Item1s);
             return newSoul;
         }
 
@@ -121,10 +121,10 @@ namespace PinionCore.Remote
                 if (typeof(IDirtyable).IsAssignableFrom(property.PropertyType))
                 {
                     var value = property.GetValue(soul.ObjectInstance);
-                    var accessable = value as IAccessable;
-                    _LoadProperty(soul.Id, id, accessable.Get());
-                }
+                    var accessible = value as IAccessable;
+                    _LoadProperty(soul.Id, id, accessible.Get());
             }
+        }
         }
 
         private void _LoadProperty(long id, int propertyId, object value)

--- a/PinionCore.Remote/SoulEventHandler.cs
+++ b/PinionCore.Remote/SoulEventHandler.cs
@@ -81,7 +81,7 @@ namespace PinionCore.Remote
         {
             MemberMap map = _Protocol.GetMemberMap();
             EventInfo info = map.GetEvent(event_id);
-            IEventProxyCreater eventCreator = _EventProvider.Find(info);
+            IEventProxyCreator eventCreator = _EventProvider.Find(info);
 
 
             return eventCreator.Create(entityId, event_id, handlerId, invokeEvent);

--- a/PinionCore.Remote/SoulProxy.cs
+++ b/PinionCore.Remote/SoulProxy.cs
@@ -55,8 +55,8 @@ namespace PinionCore.Remote
             _Dispose = () =>
             {
 
-                _Unregist(_PropertyUpdaters);
-                _Unregist(_TypeObjectNotifiables);
+                _Unregister(_PropertyUpdaters);
+                _Unregister(_TypeObjectNotifiables);
 
                 lock (_EventHandlers)
                 {
@@ -81,14 +81,14 @@ namespace PinionCore.Remote
         public void Initial(IReadOnlyDictionary<PropertyInfo, int> property_ids)
         {
             _PropertyUpdaters.AddRange(_BuildProperty(ObjectInstance, ObjectType, property_ids));
-            _Regist(_PropertyUpdaters);
+            _Register(_PropertyUpdaters);
 
             _TypeObjectNotifiables.AddRange(_BuildNotifier(ObjectInstance, ObjectType, property_ids));
-            _Regist(_TypeObjectNotifiables);
+            _Register(_TypeObjectNotifiables);
         }
 
 
-        private IEnumerable<Tuple<int, PropertyInfo>> _GetPropertys(Type soul_type, System.Collections.Generic.IReadOnlyDictionary<PropertyInfo, int> property_ids)
+        private IEnumerable<Tuple<int, PropertyInfo>> _GetProperties(Type soul_type, System.Collections.Generic.IReadOnlyDictionary<PropertyInfo, int> property_ids)
         {
             return from p in PropertyInfos
                    select new Tuple<int, PropertyInfo>(property_ids[p], p);
@@ -96,7 +96,7 @@ namespace PinionCore.Remote
 
         private IEnumerable<NotifierUpdater> _BuildNotifier(object soul, Type soul_type, System.Collections.Generic.IReadOnlyDictionary<PropertyInfo, int> propertyIds)
         {
-            return from p in _GetPropertys(soul_type, propertyIds)
+            return from p in _GetProperties(soul_type, propertyIds)
                    let property = p.Item2
                    let id = p.Item1
                    where property.PropertyType.GetInterfaces().Any(t => t == typeof(ITypeObjectNotifiable))
@@ -105,7 +105,7 @@ namespace PinionCore.Remote
         }
         private IEnumerable<PropertyUpdater> _BuildProperty(object soul, Type soul_type, System.Collections.Generic.IReadOnlyDictionary<PropertyInfo, int> propertyIds)
         {
-            foreach (Tuple<int, PropertyInfo> item in _GetPropertys(soul_type, propertyIds))
+            foreach (Tuple<int, PropertyInfo> item in _GetProperties(soul_type, propertyIds))
             {
                 PropertyInfo property = item.Item2;
                 var id = item.Item1;
@@ -121,7 +121,7 @@ namespace PinionCore.Remote
 
 
 
-        private void _Regist(List<NotifierUpdater> updaters)
+        private void _Register(List<NotifierUpdater> updaters)
         {
             foreach (NotifierUpdater updater in updaters)
             {
@@ -130,7 +130,7 @@ namespace PinionCore.Remote
                 updater.Initial();
             }
         }
-        private void _Regist(List<PropertyUpdater> property_updaters)
+        private void _Register(List<PropertyUpdater> property_updaters)
         {
             foreach (PropertyUpdater updater in property_updaters)
             {
@@ -149,7 +149,7 @@ namespace PinionCore.Remote
             _Dispose();
         }
 
-        private void _Unregist(List<PropertyUpdater> property_updaters)
+        private void _Unregister(List<PropertyUpdater> property_updaters)
         {
             foreach (PropertyUpdater updater in property_updaters)
             {
@@ -158,11 +158,11 @@ namespace PinionCore.Remote
             }
         }
 
-        private void _Unregist(List<NotifierUpdater> updaters)
+        private void _Unregister(List<NotifierUpdater> updaters)
         {
             foreach (NotifierUpdater updater in updaters)
             {
-                updater.Finial();
+                updater.Final();
                 updater.SupplyEvent -= _SupplySoul;
                 updater.UnsupplyEvent -= _UnsupplySoul;
             }

--- a/PinionCore.Samples.HelloWorld.Client/Program.cs
+++ b/PinionCore.Samples.HelloWorld.Client/Program.cs
@@ -16,7 +16,7 @@ namespace PinionCore.Samples.HelloWorld.Client
             var ip = IPAddress.Parse(args[0]);
             var port = int.Parse(args[1]);
             var protocolAsm = typeof(IGreeter).Assembly;
-            var protocol = PinionCore.Samples.HelloWorld.Protocols.ProtocolCreater.Create();
+            var protocol = PinionCore.Samples.HelloWorld.Protocols.ProtocolCreator.Create();
             var set = PinionCore.Remote.Client.Provider.CreateTcpAgent(protocol);
             var tcp = set.Connector;
             var agent = set.Agent;

--- a/PinionCore.Samples.HelloWorld.Protocols/ProtocolCreator.cs
+++ b/PinionCore.Samples.HelloWorld.Protocols/ProtocolCreator.cs
@@ -1,6 +1,6 @@
 ﻿namespace PinionCore.Samples.HelloWorld.Protocols
 {
-    public static partial class ProtocolCreater
+    public static partial class ProtocolCreator
     {
         public static PinionCore.Remote.IProtocol Create()
         {
@@ -9,7 +9,7 @@
             return p;
         }
 
-        [PinionCore.Remote.Protocol.Creater]
+        [PinionCore.Remote.Protocol.Creator]
         static partial void _Create(ref PinionCore.Remote.IProtocol p);
     }
 }

--- a/PinionCore.Samples.Helloworld.Server/Program.cs
+++ b/PinionCore.Samples.Helloworld.Server/Program.cs
@@ -6,7 +6,7 @@
         {
             int port = int.Parse(args[0]);
 
-            var protocol = PinionCore.Samples.HelloWorld.Protocols.ProtocolCreater.Create();
+            var protocol = PinionCore.Samples.HelloWorld.Protocols.ProtocolCreator.Create();
 
             var entry = new Entry();
 

--- a/PinionCore.Serialization.Test/Dynamic/SerializerTests.cs
+++ b/PinionCore.Serialization.Test/Dynamic/SerializerTests.cs
@@ -11,10 +11,10 @@ namespace PinionCore.Serialization.Dynamic.Tests
         public void TestSerializerInt()
         {
 
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
-            Memorys.Buffer buf = ser.ObjectToBuffer(12345);
-            var val = (int)ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(12345);
+            var val = (int)serializer.BufferToObject(buf);
             Assert.AreEqual(12345, val);
         }
 
@@ -22,10 +22,10 @@ namespace PinionCore.Serialization.Dynamic.Tests
         public void TestSerializerString()
         {
 
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
-            Memorys.Buffer buf = ser.ObjectToBuffer("12345");
-            var val = (string)ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer("12345");
+            var val = (string)serializer.BufferToObject(buf);
             Assert.AreEqual("12345", val);
         }
 
@@ -34,10 +34,10 @@ namespace PinionCore.Serialization.Dynamic.Tests
         public void TestSerializerNull()
         {
 
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
-            Memorys.Buffer buf = ser.ObjectToBuffer(null);
-            var val = ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(null);
+            var val = serializer.BufferToObject(buf);
             Assert.AreEqual(null, val);
         }
 
@@ -46,10 +46,10 @@ namespace PinionCore.Serialization.Dynamic.Tests
         public void TestSerializerArray()
         {
 
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
-            Memorys.Buffer buf = ser.ObjectToBuffer(new[] { 1, 2, 3, 4, 5 });
-            var val = (int[])ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(new[] { 1, 2, 3, 4, 5 });
+            var val = (int[])serializer.BufferToObject(buf);
             Assert.AreEqual(1, val[0]);
             Assert.AreEqual(2, val[1]);
             Assert.AreEqual(3, val[2]);
@@ -64,10 +64,10 @@ namespace PinionCore.Serialization.Dynamic.Tests
         public void TestSerializerStringArray()
         {
 
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
-            Memorys.Buffer buf = ser.ObjectToBuffer(new[] { "1", "2", "3", "4", "5" });
-            var val = (string[])ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(new[] { "1", "2", "3", "4", "5" });
+            var val = (string[])serializer.BufferToObject(buf);
             Assert.AreEqual("1", val[0]);
             Assert.AreEqual("2", val[1]);
             Assert.AreEqual("3", val[2]);
@@ -81,7 +81,7 @@ namespace PinionCore.Serialization.Dynamic.Tests
         [NUnit.Framework.Test]
         public void TestInherit()
         {
-            var ser = new PinionCore.Serialization.Dynamic.Serializer();
+            var serializer = new PinionCore.Serialization.Dynamic.Serializer();
 
 
             var test = new TestGrandson();
@@ -91,8 +91,8 @@ namespace PinionCore.Serialization.Dynamic.Tests
             var testParent = test as TestParent;
             testParent.Data = 33;
 
-            Memorys.Buffer buf = ser.ObjectToBuffer(test);
-            var val = (TestGrandson)ser.BufferToObject(buf);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(test);
+            var val = (TestGrandson)serializer.BufferToObject(buf);
             var valParent = val as TestParent;
             var child = val as TestChild;
 

--- a/PinionCore.Serialization.Test/PackageReleaseTests.cs
+++ b/PinionCore.Serialization.Test/PackageReleaseTests.cs
@@ -16,14 +16,14 @@ namespace PinionCore.Remote.Tests
             var id = Guid.NewGuid();
             var package1 = new TestPackageData();
 
-            var ser = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(Guid), typeof(TestPackageData)).Describers);
+            var serializer = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(Guid), typeof(TestPackageData)).Describers);
             package1.Id = id;
 
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(package1);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(package1);
 
 
-            var package2 = ser.BufferToObject(buffer) as TestPackageData;
+            var package2 = serializer.BufferToObject(buffer) as TestPackageData;
 
             NUnit.Framework.Assert.AreEqual(id, package2.Id);
         }
@@ -36,21 +36,21 @@ namespace PinionCore.Remote.Tests
             var p2 = "234";
             var p3 = Guid.NewGuid();
             var package1 = new TestPackageBuffer();
-            var ser = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(int), typeof(string), typeof(char[]), typeof(byte), typeof(byte[]), typeof(byte[][]), typeof(char), typeof(Guid), typeof(TestPackageBuffer)).Describers);
+            var serializer = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(int), typeof(string), typeof(char[]), typeof(byte), typeof(byte[]), typeof(byte[][]), typeof(char), typeof(Guid), typeof(TestPackageBuffer)).Describers);
 
 
-            package1.Datas = new[] { ser.ObjectToBuffer(p1).ToArray(), ser.ObjectToBuffer(p2).ToArray(), ser.ObjectToBuffer(p3).ToArray() };
+            package1.Data = new[] { serializer.ObjectToBuffer(p1).ToArray(), serializer.ObjectToBuffer(p2).ToArray(), serializer.ObjectToBuffer(p3).ToArray() };
 
-            //byte[] buffer = package1.ToBuffer(ser);
-            Memorys.Buffer buffer = ser.ObjectToBuffer(package1);
+            //byte[] buffer = package1.ToBuffer(serializer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(package1);
 
-            //TestPackageBuffer package2 = buffer.ToPackageData<TestPackageBuffer>(ser);
-            var package2 = ser.BufferToObject(buffer) as TestPackageBuffer;
+            //TestPackageBuffer package2 = buffer.ToPackageData<TestPackageBuffer>(serializer);
+            var package2 = serializer.BufferToObject(buffer) as TestPackageBuffer;
 
 
-            NUnit.Framework.Assert.AreEqual(p1, ser.BufferToObject(package2.Datas[0].AsBuffer()));
-            NUnit.Framework.Assert.AreEqual(p2, ser.BufferToObject(package2.Datas[1].AsBuffer()));
-            NUnit.Framework.Assert.AreEqual(p3, ser.BufferToObject(package2.Datas[2].AsBuffer()));
+            NUnit.Framework.Assert.AreEqual(p1, serializer.BufferToObject(package2.Data[0].AsBuffer()));
+            NUnit.Framework.Assert.AreEqual(p2, serializer.BufferToObject(package2.Data[1].AsBuffer()));
+            NUnit.Framework.Assert.AreEqual(p3, serializer.BufferToObject(package2.Data[2].AsBuffer()));
         }
 
 
@@ -80,13 +80,13 @@ namespace PinionCore.Remote.Tests
                             typeof(PinionCore.Remote.Packages.PackageUnloadSoul),
                             typeof(PinionCore.Remote.Packages.PackageCallMethod),
                             typeof(PinionCore.Remote.Packages.PackageRelease));
-            var ser = new PinionCore.Serialization.Serializer(builder.Describers);
+            var serializer = new PinionCore.Serialization.Serializer(builder.Describers);
             var response = new PinionCore.Remote.Packages.RequestPackage();
             response.Code = ClientToServerOpCode.Ping;
             response.Data = new byte[] { 0, 1, 2, 3, 4, 5 };
 
-            Memorys.Buffer bufferResponse = ser.ObjectToBuffer(response);
-            var result = (PinionCore.Remote.Packages.RequestPackage)ser.BufferToObject(bufferResponse);
+            Memorys.Buffer bufferResponse = serializer.ObjectToBuffer(response);
+            var result = (PinionCore.Remote.Packages.RequestPackage)serializer.BufferToObject(bufferResponse);
             NUnit.Framework.Assert.AreEqual(ClientToServerOpCode.Ping, result.Code);
             NUnit.Framework.Assert.AreEqual(3, result.Data[3]);
         }
@@ -104,17 +104,17 @@ namespace PinionCore.Remote.Tests
 
             var package1 = new TestPackageBuffer();
 
-            var ser = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(int), typeof(string), typeof(char[]), typeof(byte), typeof(byte[]), typeof(byte[][]), typeof(char), typeof(Guid), typeof(TestPackageBuffer)).Describers);
+            var serializer = new PinionCore.Serialization.Serializer(new DescriberBuilder(typeof(int), typeof(string), typeof(char[]), typeof(byte), typeof(byte[]), typeof(byte[][]), typeof(char), typeof(Guid), typeof(TestPackageBuffer)).Describers);
 
-            package1.Datas = new byte[0][];
+            package1.Data = new byte[0][];
 
-            //byte[] buffer = package1.ToBuffer(ser);
-            Memorys.Buffer buffer = ser.ObjectToBuffer(package1);
+            //byte[] buffer = package1.ToBuffer(serializer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(package1);
 
-            var package2 = ser.BufferToObject(buffer) as TestPackageBuffer;
+            var package2 = serializer.BufferToObject(buffer) as TestPackageBuffer;
 
 
-            NUnit.Framework.Assert.AreEqual(0, package2.Datas.Length);
+            NUnit.Framework.Assert.AreEqual(0, package2.Data.Length);
 
         }
     }
@@ -132,10 +132,10 @@ namespace PinionCore.Remote.Tests
 
         public TestPackageBuffer()
         {
-            Datas = new byte[0][];
+            Data = new byte[0][];
         }
 
-        public byte[][] Datas;
+        public byte[][] Data;
     }
 
 

--- a/PinionCore.Serialization.Test/SerializerTests.cs
+++ b/PinionCore.Serialization.Test/SerializerTests.cs
@@ -34,9 +34,9 @@ namespace PinionCore.Serialization.Tests
         {
             var finder = new DescribersFinder(typeof(int), typeof(uint));
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
-            var ser = new Serializer(provider);
-            Memorys.Buffer buf = ser.ObjectToBuffer(-1);
-            var val = (int)ser.BufferToObject(buf);
+            var serializer = new Serializer(provider);
+            Memorys.Buffer buf = serializer.ObjectToBuffer(-1);
+            var val = (int)serializer.BufferToObject(buf);
 
             Assert.AreEqual(-1, val);
         }
@@ -46,9 +46,9 @@ namespace PinionCore.Serialization.Tests
         {
             var finder = new DescribersFinder(typeof(long), typeof(uint));
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
-            var ser = new Serializer(provider);
-            Memorys.Buffer buf = ser.ObjectToBuffer((long)-1);
-            var val = (long)ser.BufferToObject(buf);
+            var serializer = new Serializer(provider);
+            Memorys.Buffer buf = serializer.ObjectToBuffer((long)-1);
+            var val = (long)serializer.BufferToObject(buf);
 
             Assert.AreEqual(-1, val);
         }
@@ -159,11 +159,11 @@ namespace PinionCore.Serialization.Tests
 
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(1UL);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(1UL);
 
-            var value = ser.BufferToObject(buffer);
+            var value = serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual(1UL, value);
         }
@@ -175,11 +175,11 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(int), typeof(TestClassB));
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
             var testb = new TestClassB();
             testb.Data = 1234;
-            Memorys.Buffer buffer = ser.ObjectToBuffer(testb);
-            var value = ser.BufferToObject(buffer) as TestClassB;
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(testb);
+            var value = serializer.BufferToObject(buffer) as TestClassB;
 
             NUnit.Framework.Assert.AreEqual(testb.Data, value.Data);
         }
@@ -194,7 +194,7 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
             TestClassB[] testbs = new[]
             {
                 null,
@@ -210,8 +210,8 @@ namespace PinionCore.Serialization.Tests
                 null,
             };
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(testbs);
-            var value = ser.BufferToObject(buffer) as TestClassB[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(testbs);
+            var value = serializer.BufferToObject(buffer) as TestClassB[];
 
             NUnit.Framework.Assert.AreEqual(null, value[0]);
             NUnit.Framework.Assert.AreEqual(1, value[1].Data);
@@ -229,22 +229,22 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer byteBuffer = ser.ObjectToBuffer((byte)128);
-            var byteValue = (byte)ser.BufferToObject(byteBuffer);
+            Memorys.Buffer byteBuffer = serializer.ObjectToBuffer((byte)128);
+            var byteValue = (byte)serializer.BufferToObject(byteBuffer);
 
-            Memorys.Buffer shortBuffer = ser.ObjectToBuffer((short)16387);
-            var shortValue = (short)ser.BufferToObject(shortBuffer);
+            Memorys.Buffer shortBuffer = serializer.ObjectToBuffer((short)16387);
+            var shortValue = (short)serializer.BufferToObject(shortBuffer);
 
-            Memorys.Buffer intBuffer = ser.ObjectToBuffer(65535);
-            var intValue = (int)ser.BufferToObject(intBuffer);
+            Memorys.Buffer intBuffer = serializer.ObjectToBuffer(65535);
+            var intValue = (int)serializer.BufferToObject(intBuffer);
 
-            Memorys.Buffer longBuffer = ser.ObjectToBuffer((long)65535000);
-            var longValue = (long)ser.BufferToObject(longBuffer);
+            Memorys.Buffer longBuffer = serializer.ObjectToBuffer((long)65535000);
+            var longValue = (long)serializer.BufferToObject(longBuffer);
 
-            Memorys.Buffer enumBuffer = ser.ObjectToBuffer(TEST1.C);
-            var enumValue = (TEST1)ser.BufferToObject(enumBuffer);
+            Memorys.Buffer enumBuffer = serializer.ObjectToBuffer(TEST1.C);
+            var enumValue = (TEST1)serializer.BufferToObject(enumBuffer);
 
             NUnit.Framework.Assert.AreEqual((byte)128, byteValue);
             NUnit.Framework.Assert.AreEqual((short)16387, shortValue);
@@ -262,7 +262,7 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder.KeyDescriber, finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
             var ints = new[]
             {
@@ -276,8 +276,8 @@ namespace PinionCore.Serialization.Tests
                 323,
                 78
             };
-            Memorys.Buffer buffer = ser.ObjectToBuffer(ints);
-            var value = (int[])ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(ints);
+            var value = (int[])serializer.BufferToObject(buffer);
 
 
             NUnit.Framework.Assert.AreEqual(46, value[1]);
@@ -292,7 +292,7 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
             var ints = new[]
             {
@@ -306,8 +306,8 @@ namespace PinionCore.Serialization.Tests
                 323f,
                 78f
             };
-            Memorys.Buffer buffer = ser.ObjectToBuffer(ints);
-            var value = (float[])ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(ints);
+            var value = (float[])serializer.BufferToObject(buffer);
 
 
             NUnit.Framework.Assert.AreEqual(46f, value[1]);
@@ -321,10 +321,10 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(float));
             var provider = new DescriberProvider(finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(123.43f);
-            var value = (float)ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(123.43f);
+            var value = (float)serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual(123.43f, value);
         }
@@ -337,10 +337,10 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(new byte[] { 1, 2, 3, 4, 5, 6 });
-            var value = (byte[])ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(new byte[] { 1, 2, 3, 4, 5, 6 });
+            var value = (byte[])serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual(1, value[0]);
             NUnit.Framework.Assert.AreEqual(2, value[1]);
@@ -355,10 +355,10 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(char[]));
             var provider = new DescriberProvider(finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(new char[] { '1', '2', 'a', 'b', 'c', 't' });
-            var value = (char[])ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(new char[] { '1', '2', 'a', 'b', 'c', 't' });
+            var value = (char[])serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual('1', value[0]);
             NUnit.Framework.Assert.AreEqual('2', value[1]);
@@ -376,10 +376,10 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(char[]));
             var provider = new DescriberProvider(finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
             var str = "asdfgh";
-            Memorys.Buffer buffer = ser.ObjectToBuffer(str.ToCharArray());
-            var value = (char[])ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(str.ToCharArray());
+            var value = (char[])serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual('a', value[0]);
             NUnit.Framework.Assert.AreEqual('s', value[1]);
@@ -398,11 +398,11 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(Guid), typeof(Guid[]));
             var provider = new DescriberProvider(finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
             var id = Guid.NewGuid();
-            Memorys.Buffer buffer = ser.ObjectToBuffer(id);
-            var value = (Guid)ser.BufferToObject(buffer);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(id);
+            var value = (Guid)serializer.BufferToObject(buffer);
 
             NUnit.Framework.Assert.AreEqual(id, value);
         }
@@ -417,7 +417,7 @@ namespace PinionCore.Serialization.Tests
 
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
             var cs = new TestClassC[]
             {
@@ -427,8 +427,8 @@ namespace PinionCore.Serialization.Tests
             };
 
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(cs);
-            var value = ser.BufferToObject(buffer) as TestClassC[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(cs);
+            var value = serializer.BufferToObject(buffer) as TestClassC[];
 
 
             NUnit.Framework.Assert.AreEqual(cs[0], value[0]);
@@ -444,10 +444,10 @@ namespace PinionCore.Serialization.Tests
             var finder = new DescribersFinder(typeof(TestClassC), typeof(TestClassC[]));
             var provider = new DescriberProvider(finder);
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(null);
-            var value = ser.BufferToObject(buffer) as TestClassC[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(null);
+            var value = serializer.BufferToObject(buffer) as TestClassC[];
 
 
             NUnit.Framework.Assert.AreEqual(null, value);
@@ -480,10 +480,10 @@ namespace PinionCore.Serialization.Tests
                 0
             };
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(bytes);
-            var result = ser.BufferToObject(buffer) as byte[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(bytes);
+            var result = serializer.BufferToObject(buffer) as byte[];
 
             NUnit.Framework.Assert.AreEqual(bytes[3], result[3]);
             NUnit.Framework.Assert.AreEqual(bytes[1], result[1]);
@@ -517,10 +517,10 @@ namespace PinionCore.Serialization.Tests
 
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
-            Memorys.Buffer buffer = ser.ObjectToBuffer(bytes);
-            var result = ser.BufferToObject(buffer) as byte[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(bytes);
+            var result = serializer.BufferToObject(buffer) as byte[];
 
             NUnit.Framework.Assert.AreEqual(bytes[3], result[3]);
             NUnit.Framework.Assert.AreEqual(bytes[1], result[1]);
@@ -537,12 +537,12 @@ namespace PinionCore.Serialization.Tests
 
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
 
             var str = "fliwjfo3f3fnmsdlgmnlgrkmbr'nhmlredhgnedra'lngh";
-            Memorys.Buffer buffer = ser.ObjectToBuffer(str);
-            var value = ser.BufferToObject(buffer) as string;
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(str);
+            var value = serializer.BufferToObject(buffer) as string;
 
             NUnit.Framework.Assert.AreEqual(str, value);
         }
@@ -556,12 +556,12 @@ namespace PinionCore.Serialization.Tests
             var provider = new DescriberProvider(finder);
 
 
-            var ser = new Serializer(provider);
+            var serializer = new Serializer(provider);
 
 
             var str = new char[] { 'd', 'a' };
-            Memorys.Buffer buffer = ser.ObjectToBuffer(str);
-            var value = ser.BufferToObject(buffer) as char[];
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(str);
+            var value = serializer.BufferToObject(buffer) as char[];
 
             NUnit.Framework.Assert.AreEqual(str[0], value[0]);
             NUnit.Framework.Assert.AreEqual(str[1], value[1]);
@@ -572,11 +572,11 @@ namespace PinionCore.Serialization.Tests
         public void TestSerializerVector2()
         {
 
-            var ser = new Serializer(new DescriberBuilder(typeof(PinionCore.Utility.Vector2), typeof(float)).Describers);
+            var serializer = new Serializer(new DescriberBuilder(typeof(PinionCore.Utility.Vector2), typeof(float)).Describers);
             var v = new PinionCore.Utility.Vector2(99, 22);
 
-            Memorys.Buffer array = ser.ObjectToBuffer(v);
-            var v2 = (PinionCore.Utility.Vector2)ser.BufferToObject(array);
+            Memorys.Buffer array = serializer.ObjectToBuffer(v);
+            var v2 = (PinionCore.Utility.Vector2)serializer.BufferToObject(array);
 
             NUnit.Framework.Assert.AreEqual(99, v2.X);
             NUnit.Framework.Assert.AreEqual(22, v2.Y);
@@ -588,11 +588,11 @@ namespace PinionCore.Serialization.Tests
         {
             Type[] types = new[] { typeof(int), typeof(int[]), typeof(float), typeof(string), typeof(char), typeof(char[]) };
 
-            var ser = new Serializer(new DescriberBuilder(types).Describers);
+            var serializer = new Serializer(new DescriberBuilder(types).Describers);
 
-            Memorys.Buffer intZeroBuffer = ser.ObjectToBuffer("123");
+            Memorys.Buffer intZeroBuffer = serializer.ObjectToBuffer("123");
 
-            var intZero = ser.BufferToObject(intZeroBuffer);
+            var intZero = serializer.BufferToObject(intZeroBuffer);
 
 
             Assert.AreEqual("123", intZero);
@@ -603,13 +603,13 @@ namespace PinionCore.Serialization.Tests
         {
             Type[] types = new[] { typeof(PinionCore.Remote.Packages.ResponsePackage), typeof(Remote.ServerToClientOpCode), typeof(byte), typeof(byte[]) };
 
-            var ser = new Serializer(new DescriberBuilder(types).Describers);
+            var serializer = new Serializer(new DescriberBuilder(types).Describers);
             var pkg = new PinionCore.Remote.Packages.ResponsePackage();
             pkg.Code = Remote.ServerToClientOpCode.SetProperty;
             pkg.Data = new byte[1] { 255 };
-            Memorys.Buffer buffer = ser.ObjectToBuffer(pkg);
+            Memorys.Buffer buffer = serializer.ObjectToBuffer(pkg);
 
-            var dPkg = (PinionCore.Remote.Packages.ResponsePackage)ser.BufferToObject(buffer);
+            var dPkg = (PinionCore.Remote.Packages.ResponsePackage)serializer.BufferToObject(buffer);
 
 
             Assert.AreEqual(Remote.ServerToClientOpCode.SetProperty, dPkg.Code);

--- a/PinionCore.Serialization/ArrayDescriber.cs
+++ b/PinionCore.Serialization/ArrayDescriber.cs
@@ -157,7 +157,7 @@ namespace PinionCore.Serialization
 
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             try
             {
@@ -165,7 +165,7 @@ namespace PinionCore.Serialization
                 ulong count;
                 offset += Varint.BufferToNumber(buffer, offset, out count);
                 var array = Activator.CreateInstance(_Type, (int)count) as IList;
-                instnace = array;
+                instance = array;
 
                 ulong validCount;
                 offset += Varint.BufferToNumber(buffer, offset, out validCount);

--- a/PinionCore.Serialization/BlittableDescriber.cs
+++ b/PinionCore.Serialization/BlittableDescriber.cs
@@ -86,7 +86,7 @@ namespace PinionCore.Serialization
             return readCount;
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
 
             try
@@ -98,7 +98,7 @@ namespace PinionCore.Serialization
 
                 Marshal.Copy(bytes.Array, bytes.Offset + begin, ptr, size);
 
-                instnace = Marshal.PtrToStructure(ptr, _Type);
+                instance = Marshal.PtrToStructure(ptr, _Type);
                 Marshal.FreeHGlobal(ptr);
                 return size;
             }

--- a/PinionCore.Serialization/BufferDescriber.cs
+++ b/PinionCore.Serialization/BufferDescriber.cs
@@ -58,7 +58,7 @@ namespace PinionCore.Serialization
             return offset - begin + bufferLength;
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             var offset = begin;
             var bufferLen = 0;
@@ -70,7 +70,7 @@ namespace PinionCore.Serialization
             ArraySegment<byte> bytes = buffer.Bytes;
             Buffer.BlockCopy(bytes.Array, bytes.Offset + offset, dst, 0, bufferLen);
 
-            instnace = dst;
+            instance = dst;
             return offset - begin + bufferLen;
         }
 

--- a/PinionCore.Serialization/ByteArrayDescriber.cs
+++ b/PinionCore.Serialization/ByteArrayDescriber.cs
@@ -47,7 +47,7 @@ namespace PinionCore.Serialization
             return offset - begin;
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             var offset = begin;
             object lenObject = null;
@@ -59,7 +59,7 @@ namespace PinionCore.Serialization
             {
                 array[i] = buffer[offset++];
             }
-            instnace = array;
+            instance = array;
             return offset - begin;
         }
 

--- a/PinionCore.Serialization/EnumDescriber.cs
+++ b/PinionCore.Serialization/EnumDescriber.cs
@@ -49,13 +49,13 @@ namespace PinionCore.Serialization
             return Varint.NumberToBuffer(bytes.Array, bytes.Offset + begin, Convert.ToUInt64(instance));
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             ulong value;
-            var readed = Varint.BufferToNumber(buffer, begin, out value);
+            var bytesRead = Varint.BufferToNumber(buffer, begin, out value);
 
-            instnace = Enum.ToObject(_Type, value);
-            return readed;
+            instance = Enum.ToObject(_Type, value);
+            return bytesRead;
         }
 
 

--- a/PinionCore.Serialization/ITypeDescriber.cs
+++ b/PinionCore.Serialization/ITypeDescriber.cs
@@ -11,6 +11,6 @@ namespace PinionCore.Serialization
 
         int GetByteCount(object instance);
         int ToBuffer(object instance, PinionCore.Memorys.Buffer buffer, int begin);
-        int ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace);
+        int ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance);
     }
 }

--- a/PinionCore.Serialization/NumberDescriber.cs
+++ b/PinionCore.Serialization/NumberDescriber.cs
@@ -73,7 +73,7 @@ namespace PinionCore.Serialization
         int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             ulong value;
-            var readed = Varint.BufferToNumber(buffer, begin, out value);
+            var bytesRead = Varint.BufferToNumber(buffer, begin, out value);
 
             if (Type == typeof(byte))
             {
@@ -113,7 +113,7 @@ namespace PinionCore.Serialization
             }
 
 
-            return readed;
+            return bytesRead;
         }
 
 

--- a/PinionCore.Serialization/Serializer.cs
+++ b/PinionCore.Serialization/Serializer.cs
@@ -89,7 +89,7 @@ namespace PinionCore.Serialization
                     throw new SystemException(string.Format("BufferToObject {0}:{1}", id, describer.Type.FullName), ex);
                 else
                 {
-                    throw new SystemException(string.Format("BufferToObject {0}:unkown", id), ex);
+                    throw new SystemException(string.Format("BufferToObject {0}:unknown", id), ex);
                 }
             }
 

--- a/PinionCore.Serialization/StringDescriber.cs
+++ b/PinionCore.Serialization/StringDescriber.cs
@@ -44,13 +44,13 @@ namespace PinionCore.Serialization
             return offset - begin;
         }
 
-        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instnace)
+        int ITypeDescriber.ToObject(PinionCore.Memorys.Buffer buffer, int begin, out object instance)
         {
             var offset = begin;
             object chars;
             offset += _CharArrayDescriber.ToObject(buffer, offset, out chars);
 
-            instnace = new string(chars as char[]);
+            instance = new string(chars as char[]);
 
             return offset - begin;
         }

--- a/README-tc.md
+++ b/README-tc.md
@@ -160,12 +160,12 @@ namespace Protocol
 }
 ```
 
-3) 新增 `ProtocolCreater.cs` 以產生 `IProtocol`
+3) 新增 `ProtocolCreator.cs` 以產生 `IProtocol`
 
 ```csharp
 namespace Protocol
 {
-	public static partial class ProtocolCreater
+	public static partial class ProtocolCreator
 	{
 		public static PinionCore.Remote.IProtocol Create()
 		{
@@ -174,13 +174,13 @@ namespace Protocol
 			return protocol;
 		}
 
-		[PinionCore.Remote.Protocol.Creater]
+		[PinionCore.Remote.Protocol.Creator]
 		static partial void _Create(ref PinionCore.Remote.IProtocol protocol);
 	}
 }
 ```
 
-注意：被標記為 `PinionCore.Remote.Protocol.Creater` 的方法需為 `static partial void Method(ref PinionCore.Remote.IProtocol)`，否則無法編譯通過。
+注意：被標記為 `PinionCore.Remote.Protocol.Creator` 的方法需為 `static partial void Method(ref PinionCore.Remote.IProtocol)`，否則無法編譯通過。
 
 ### Server 專案
 
@@ -244,7 +244,7 @@ namespace Server
 {
 	static void Main(string[] args)
 	{
-		var protocol = Protocol.ProtocolCreater.Create();
+		var protocol = Protocol.ProtocolCreator.Create();
 		var entry = new Entry();
 		var set = PinionCore.Remote.Server.Provider.CreateTcpService(entry, protocol);
 		int yourPort = 0;
@@ -279,7 +279,7 @@ namespace Client
 {
 	static async Task Main(string[] args)
 	{
-		var protocol = Protocol.ProtocolCreater.Create();
+		var protocol = Protocol.ProtocolCreator.Create();
 		var set = PinionCore.Remote.Client.Provider.CreateTcpAgent(protocol);
 
 		bool stop = false;
@@ -319,7 +319,7 @@ namespace Client
 無需網路即可模擬 Server/Client：
 
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 var entry = new Entry();
 var service = PinionCore.Remote.Standalone.Provider.CreateService(entry , protocol);
 var agent = service.Create();
@@ -332,7 +332,7 @@ var agent = service.Create();
 客戶端以 `CreateAgent(protocol, IStreamable)` 建立，並自行實作 `IStreamable`：
 
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 IStreamable stream = null; // 自行實作 IStreamable
 var service = PinionCore.Remote.Client.CreateAgent(protocol, stream);
 ```

--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ namespace Protocol
 	}
 }
 ```
-3. Add ```ProtocolCreater.cs```.
+3. Add ```ProtocolCreator.cs```.
 ```csharp
 namespace Protocol
 {
-    public static partial class ProtocolCreater
+    public static partial class ProtocolCreator
     {
         public static PinionCore.Remote.IProtocol Create()
         {
@@ -226,7 +226,7 @@ namespace Protocol
         /*
 			Create a partial method as follows.
         */
-        [PinionCore.Remote.Protocol.Creater]
+        [PinionCore.Remote.Protocol.Creator]
         static partial void _Create(ref PinionCore.Remote.IProtocol protocol);
     }
 }
@@ -292,8 +292,8 @@ namespace Server
 {	
 	static void Main(string[] args)
 	{		
-		// Get IProtocol with ProtocolCreater
-		var protocol = Protocol.ProtocolCreater.Create();
+		// Get IProtocol with ProtocolCreator
+		var protocol = Protocol.ProtocolCreator.Create();
 		
 		// Create Service
 		var entry = new Entry();		
@@ -329,8 +329,8 @@ namespace Client
 {	
 	static async Task Main(string[] args)
 	{		
-		// Get IProtocol with ProtocolCreater
-		var protocol = Protocol.ProtocolCreater.Create();
+		// Get IProtocol with ProtocolCreator
+		var protocol = Protocol.ProtocolCreator.Create();
 				
 		var set = PinionCore.Remote.Client.Provider.CreateTcpAgent(protocol);
 		
@@ -391,8 +391,8 @@ namespace Standalone
 {	
 	static void Main(string[] args)
 	{		
-		// Get IProtocol with ProtocolCreater
-		var protocol = Protocol.ProtocolCreater.Create();
+		// Get IProtocol with ProtocolCreator
+		var protocol = Protocol.ProtocolCreator.Create();
 		
 		// Create service
 		var entry = new Entry();
@@ -438,7 +438,7 @@ If you want to customize the connection system you can do so in the following wa
 #### Client
 Create a connection use ```CreateAgent``` and implement the interface ```IStreamable```.
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 IStreamable stream = null ;// todo: Implementation Interface IStreamable
 var service = PinionCore.Remote.Client.CreateAgent(protocol , stream) ;
 ```
@@ -473,7 +473,7 @@ namespace PinionCore.Network
 
 Create a service use ```CreateService``` and implement the interface ```IListenable```.
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 var entry = new Entry();
 IListenable listener = null; // todo: Implementation Interface IListenable
 var service = PinionCore.Remote.Server.CreateService(entry , protocol , listener) ;
@@ -506,7 +506,7 @@ namespace PinionCore.Remote
 ```
 and bring it to the server ```CreateTcpService```.
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 var entry = new Entry();
 ISerializable yourSerializer = null; 
 var service = PinionCore.Remote.Server.CreateTcpService(entry , protocol , yourSerializer) ;
@@ -514,7 +514,7 @@ var service = PinionCore.Remote.Server.CreateTcpService(entry , protocol , yourS
 
 and bring it to the client ```CreateTcpAgent```.
 ```csharp
-var protocol = Protocol.ProtocolCreater.Create();
+var protocol = Protocol.ProtocolCreator.Create();
 ISerializable yourSerializer = null ;
 var service = PinionCore.Remote.Client.CreateTcpAgent(protocol , yourSerializer) ;
 ```  

--- a/document/communications-method.md
+++ b/document/communications-method.md
@@ -9,7 +9,7 @@ public interface IFoo
 ```
 The server implements the method.  
 ```csharp
-namesapce Server
+namespace Server
 {
     class Foo : IFoo
     {
@@ -22,7 +22,7 @@ namesapce Server
 ```
 You can accept the return value on the client side by the following methods.  
 ```csharp
-namesapce Client
+namespace Client
 {
     class Bar 
     {

--- a/document/communications-property.md
+++ b/document/communications-property.md
@@ -9,7 +9,7 @@ public interface IFoo
 ```
 The server implements the property.  
 ```csharp
-namesapce Server
+namespace Server
 {
     class Foo : IFoo
     {


### PR DESCRIPTION
## Summary
- revert PinionCore.Utility submodule pointer to the previous commit used by the repository

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc7f485a58832ebcae10383fb1d578