### PR TITLE
Add cancellation tokens to package reader loops

### DIFF
--- a/PinionCore.Remote.Gateway/Frontends/FrontServer.cs
+++ b/PinionCore.Remote.Gateway/Frontends/FrontServer.cs
@@ -319,7 +319,15 @@ namespace PinionCore.Remote.Gateway.Frontends
             {
                 while (!token.IsCancellationRequested)
                 {
-                    var buffers = await _clientReader.Read().ConfigureAwait(false);
+                    List<Memorys.Buffer> buffers;
+                    try
+                    {
+                        buffers = await _clientReader.Read(token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
                     if (buffers == null || buffers.Count == 0)
                     {
                         continue;


### PR DESCRIPTION
## Summary
- ensure gateway channels cancel and dispose their package readers on disconnect and disposal
- propagate cancellation tokens through front-end, ghost, and soul reader loops for orderly shutdown
- update the ListenableSubscriber test helper to cancel package reader tasks when the subscription ends

## Testing
- dotnet build PinionCore.sln
- dotnet test PinionCore.Remote.Gateway.Test/PinionCore.Remote.Gateway.Test.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cee071f82c832e9b9089fa4b901f75