### PR TITLE
Add customizable lobby selection with round robin strategy

### DIFF
--- a/PinionCore.Remote.Gateway/Hosts/GatewayHostServiceHub.cs
+++ b/PinionCore.Remote.Gateway/Hosts/GatewayHostServiceHub.cs
@@ -10,9 +10,9 @@ namespace PinionCore.Remote.Gateway.Hosts
         public readonly IService Service;
         public readonly IServiceRegistry Registry;
 
-        public GatewayHostServiceHub()
+        public GatewayHostServiceHub(IGameLobbySelectionStrategy selectionStrategy = null)
         {
-            _sessionCoordinator = new GatewayHostSessionCoordinator();
+            _sessionCoordinator = new GatewayHostSessionCoordinator(selectionStrategy);
             Registry = _sessionCoordinator;
             _clientEntry = new GatewayHostClientEntry(_sessionCoordinator);
             var protocol = PinionCore.Remote.Gateway.Protocols.ProtocolProvider.Create();

--- a/PinionCore.Remote.Gateway/Hosts/IGameLobbySelectionStrategy.cs
+++ b/PinionCore.Remote.Gateway/Hosts/IGameLobbySelectionStrategy.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using PinionCore.Remote.Gateway.Protocols;
+
+namespace PinionCore.Remote.Gateway.Hosts
+{
+    /// <summary>
+    /// Defines a strategy for ordering <see cref="IGameLobby"/> instances when binding sessions.
+    /// </summary>
+    public interface IGameLobbySelectionStrategy
+    {
+        /// <summary>
+        /// Produces an ordered set of candidate lobbies for the specified group.
+        /// </summary>
+        /// <param name="group">The group identifier for the requested binding.</param>
+        /// <param name="services">The currently registered lobbies for the group.</param>
+        /// <returns>An ordered sequence of lobbies to probe for binding.</returns>
+        IEnumerable<IGameLobby> Select(uint group, IReadOnlyList<IGameLobby> services);
+    }
+}

--- a/PinionCore.Remote.Gateway/Hosts/RoundRobinGameLobbySelectionStrategy.cs
+++ b/PinionCore.Remote.Gateway/Hosts/RoundRobinGameLobbySelectionStrategy.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using PinionCore.Remote.Gateway.Protocols;
+
+namespace PinionCore.Remote.Gateway.Hosts
+{
+    /// <summary>
+    /// Default implementation that balances bindings by iterating lobbies in a round-robin order per group.
+    /// </summary>
+    public sealed class RoundRobinGameLobbySelectionStrategy : IGameLobbySelectionStrategy
+    {
+        private readonly Dictionary<uint, int> _nextIndices;
+
+        public RoundRobinGameLobbySelectionStrategy()
+        {
+            _nextIndices = new Dictionary<uint, int>();
+        }
+
+        public IEnumerable<IGameLobby> Select(uint group, IReadOnlyList<IGameLobby> services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (services.Count == 0)
+            {
+                return Array.Empty<IGameLobby>();
+            }
+
+            if (!_nextIndices.TryGetValue(group, out var nextIndex))
+            {
+                nextIndex = 0;
+            }
+
+            var startIndex = nextIndex % services.Count;
+            var ordered = new List<IGameLobby>(services.Count);
+            for (var i = 0; i < services.Count; i++)
+            {
+                var index = (startIndex + i) % services.Count;
+                ordered.Add(services[index]);
+            }
+
+            _nextIndices[group] = (startIndex + 1) % services.Count;
+
+            return ordered;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose an IGameLobbySelectionStrategy interface so lobby selection logic can be customized
- add a default round-robin strategy and update the session coordinator and service hub to consume it
- extend host tests with fakes that verify round-robin distribution across multiple lobbies

## Testing
- dotnet test PinionCore.Remote.Gateway.Test/PinionCore.Remote.Gateway.Test.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1e352f460832ea324902c36c92806