### PR TITLE
Add round-robin lobby selection strategy for gateway host

### DIFF
--- a/PinionCore.Remote.Gateway/Hosts/GatewayHostServiceHub.cs
+++ b/PinionCore.Remote.Gateway/Hosts/GatewayHostServiceHub.cs
@@ -10,9 +10,9 @@ namespace PinionCore.Remote.Gateway.Hosts
         public readonly IService Service;
         public readonly IServiceRegistry Registry;
 
-        public GatewayHostServiceHub()
+        public GatewayHostServiceHub(IGameLobbySelectionStrategy selectionStrategy = null)
         {
-            _sessionCoordinator = new GatewayHostSessionCoordinator();
+            _sessionCoordinator = new GatewayHostSessionCoordinator(selectionStrategy);
             Registry = _sessionCoordinator;
             _clientEntry = new GatewayHostClientEntry(_sessionCoordinator);
             var protocol = PinionCore.Remote.Gateway.Protocols.ProtocolProvider.Create();

--- a/PinionCore.Remote.Gateway/Hosts/IGameLobbySelectionStrategy.cs
+++ b/PinionCore.Remote.Gateway/Hosts/IGameLobbySelectionStrategy.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using PinionCore.Remote.Gateway.Protocols;
+
+namespace PinionCore.Remote.Gateway.Hosts
+{
+    /// <summary>
+    /// Defines the contract for selecting which <see cref="IGameLobby"/> should handle an incoming
+    /// <see cref="IRoutableSession"/> for a particular group.
+    /// </summary>
+    public interface IGameLobbySelectionStrategy
+    {
+        /// <summary>
+        /// Orders the available lobbies for the given session and group according to the strategy.
+        /// The coordinator will attempt to bind the session following the returned order.
+        /// </summary>
+        /// <param name="group">The group identifier for the requested lobby.</param>
+        /// <param name="lobbies">The current lobbies registered for the group.</param>
+        /// <returns>An ordered enumerable of lobbies to try for binding.</returns>
+        IEnumerable<IGameLobby> OrderLobbies(uint group, IReadOnlyList<IGameLobby> lobbies);
+    }
+}

--- a/PinionCore.Remote.Gateway/Hosts/RoundRobinGameLobbySelectionStrategy.cs
+++ b/PinionCore.Remote.Gateway/Hosts/RoundRobinGameLobbySelectionStrategy.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using PinionCore.Remote.Gateway.Protocols;
+
+namespace PinionCore.Remote.Gateway.Hosts
+{
+    /// <summary>
+    /// Provides a round-robin strategy for selecting lobbies within the same group.
+    /// </summary>
+    public sealed class RoundRobinGameLobbySelectionStrategy : IGameLobbySelectionStrategy
+    {
+        private readonly Dictionary<uint, int> _nextIndexByGroup = new Dictionary<uint, int>();
+
+        public IEnumerable<IGameLobby> OrderLobbies(uint group, IReadOnlyList<IGameLobby> lobbies)
+        {
+            if (lobbies == null)
+            {
+                throw new ArgumentNullException(nameof(lobbies));
+            }
+
+            if (lobbies.Count == 0)
+            {
+                _nextIndexByGroup.Remove(group);
+                return Array.Empty<IGameLobby>();
+            }
+
+            if (!_nextIndexByGroup.TryGetValue(group, out var startIndex))
+            {
+                startIndex = 0;
+            }
+
+            if (startIndex >= lobbies.Count)
+            {
+                startIndex %= lobbies.Count;
+            }
+
+            var ordered = new IGameLobby[lobbies.Count];
+            for (var i = 0; i < lobbies.Count; i++)
+            {
+                ordered[i] = lobbies[(startIndex + i) % lobbies.Count];
+            }
+
+            _nextIndexByGroup[group] = (startIndex + 1) % lobbies.Count;
+
+            return ordered;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a customizable `IGameLobbySelectionStrategy` interface with a default round-robin implementation
- update `GatewayHostSessionCoordinator` and `GatewayHostServiceHub` to consume the selection strategy when binding sessions
- add a regression test ensuring round-robin assignment balances sessions across lobbies

## Testing
- dotnet test PinionCore.Remote.Gateway.Test/PinionCore.Remote.Gateway.Test.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1e352f460832ea324902c36c92806