### PR TITLE
Ensure PackageSender waits for send completion before disposing

### DIFF
--- a/PinionCore.Network/PackageSender.cs
+++ b/PinionCore.Network/PackageSender.cs
@@ -41,6 +41,21 @@ namespace PinionCore.Network
 
         void IDisposable.Dispose()
         {
+            if (_Sending == null)
+                return;
+
+            if (!_Sending.IsCompleted)
+            {
+                try
+                {
+                    _Sending.GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // Ignore exceptions while waiting during dispose.
+                }
+            }
+
             _Sending.Dispose();
         }
 


### PR DESCRIPTION
## Summary
- wait for the active send task to complete before disposing it in `PackageSender`
- guard against null send task disposal to avoid InvalidOperationException in tests

## Testing
- dotnet test PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests/PinionCore.Remote.Tools.Protocol.Sources.TestCommon.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1efb79994832eb7d7d97d4025a7eb