### PR TITLE
Fix gateway host interface bridging and client channel IDs

### DIFF
--- a/PinionCore.Remote.Gateway/Hosts/GatewayHostClientAgentPool.cs
+++ b/PinionCore.Remote.Gateway/Hosts/GatewayHostClientAgentPool.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
-
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using PinionCore.Remote.Gateway.Protocols;
-
 using PinionCore.Remote.Ghost;
 
 namespace PinionCore.Remote.Gateway.Hosts
@@ -14,25 +17,50 @@ namespace PinionCore.Remote.Gateway.Hosts
             public IAgent Agent;
             public IClientConnection Session;
             public Servers.GatewayServerSessionAdapter Stream;
+            public List<Action> DetachHandlers;
+            public Dictionary<Type, HashSet<long>> BridgedGhosts;
+            public CancellationTokenSource PumpCancellation;
+            public Task PumpTask;
         }
 
-        readonly System.Collections.Generic.List<User> _users;
-        
+        readonly List<User> _users;
         readonly IProtocol _gameProtocol;
+        readonly Dictionary<Type, IReadOnlyList<Type>> _interfaceHierarchy;
+        readonly MethodInfo _queryNotifierMethod;
         System.Action _disable;
         public readonly Notifier<IAgent> Agents;
         public readonly IAgent Agent;
-        public GatewayHostClientAgentPool(IProtocol gameProtocol) {
-            
-            _users = new System.Collections.Generic.List<User>();
+
+        public GatewayHostClientAgentPool(IProtocol gameProtocol)
+        {
+            if (gameProtocol == null)
+            {
+                throw new ArgumentNullException(nameof(gameProtocol));
+            }
+
+            _users = new List<User>();
             _gameProtocol = gameProtocol;
             Agent = PinionCore.Remote.Gateway.Provider.CreateAgent();
             Agents = new Notifier<IAgent>();
 
+            var interfaceProvider = _gameProtocol.GetInterfaceProvider();
+            var protocolInterfaces = new HashSet<Type>(interfaceProvider.Types ?? Array.Empty<Type>());
+            _interfaceHierarchy = protocolInterfaces.ToDictionary(
+                type => type,
+                type => (IReadOnlyList<Type>)type
+                    .GetInterfaces()
+                    .Where(protocolInterfaces.Contains)
+                    .Distinct()
+                    .ToArray());
+
+            _queryNotifierMethod = typeof(INotifierQueryable).GetMethod(nameof(INotifierQueryable.QueryNotifier))
+                ?? throw new InvalidOperationException("Failed to locate QueryNotifier method.");
+
             Agent.QueryNotifier<IConnectionManager>().Supply += _Create;
             Agent.QueryNotifier<IConnectionManager>().Unsupply += _Destroy;
 
-            _disable = () => {
+            _disable = () =>
+            {
                 Agent.QueryNotifier<IConnectionManager>().Supply -= _Create;
                 Agent.QueryNotifier<IConnectionManager>().Unsupply -= _Destroy;
             };
@@ -42,7 +70,7 @@ namespace PinionCore.Remote.Gateway.Hosts
         {
             owner.Connections.Base.Supply -= _Create;
             owner.Connections.Base.Unsupply -= _Destroy;
-        }        
+        }
 
         private void _Create(IConnectionManager owner)
         {
@@ -55,14 +83,12 @@ namespace PinionCore.Remote.Gateway.Hosts
             for (var i = _users.Count - 1; i >= 0; i--)
             {
                 var user = _users[i];
-                if (user.Session != session)
+                if (!ReferenceEquals(user.Session, session))
                 {
                     continue;
                 }
 
-                Agents.Collection.Remove(user.Agent);
-                user.Agent.Disable();
-                user.Stream?.Dispose();
+                _RemoveUser(user);
                 _users.RemoveAt(i);
             }
         }
@@ -72,28 +98,262 @@ namespace PinionCore.Remote.Gateway.Hosts
             var agent = PinionCore.Remote.Standalone.Provider.CreateAgent(_gameProtocol);
             var stream = new Servers.GatewayServerSessionAdapter(session);
             agent.Enable(stream);
+
             var user = new User
             {
                 Agent = agent,
                 Session = session,
                 Stream = stream,
+                DetachHandlers = new List<Action>(),
+                BridgedGhosts = new Dictionary<Type, HashSet<long>>()
             };
+
+            _SetupInterfaceBridging(user);
+            _StartPump(user);
+
             _users.Add(user);
             Agents.Collection.Add(user.Agent);
         }
+
         public void Dispose()
         {
-            // Dispose all tracked agents and unsubscribe from connection manager events
             for (var i = _users.Count - 1; i >= 0; i--)
             {
                 var user = _users[i];
-                Agents.Collection.Remove(user.Agent);
-                user.Agent.Disable();
-                user.Stream?.Dispose();
-                _users.RemoveAt(i);
+                _RemoveUser(user);
             }
 
-            _disable();
+            _users.Clear();
+            _disable?.Invoke();
+        }
+
+        private void _SetupInterfaceBridging(User user)
+        {
+            foreach (var kvp in _interfaceHierarchy)
+            {
+                var derivedType = kvp.Key;
+                var baseTypes = kvp.Value;
+                if (baseTypes.Count == 0)
+                {
+                    continue;
+                }
+
+                var derivedNotifier = _InvokeQueryNotifier(user.Agent, derivedType);
+                if (derivedNotifier == null)
+                {
+                    continue;
+                }
+
+                var notifierType = typeof(INotifier<>).MakeGenericType(derivedType);
+                var supplyEvent = notifierType.GetEvent("Supply");
+                var unsupplyEvent = notifierType.GetEvent("Unsupply");
+
+                if (supplyEvent == null || unsupplyEvent == null)
+                {
+                    continue;
+                }
+
+                var supplyHandler = _CreateSupplyHandler(user, baseTypes, derivedType);
+                var unsupplyHandler = _CreateUnsupplyHandler(user, baseTypes, derivedType);
+
+                supplyEvent.AddEventHandler(derivedNotifier, supplyHandler);
+                unsupplyEvent.AddEventHandler(derivedNotifier, unsupplyHandler);
+
+                user.DetachHandlers.Add(() =>
+                {
+                    supplyEvent.RemoveEventHandler(derivedNotifier, supplyHandler);
+                    unsupplyEvent.RemoveEventHandler(derivedNotifier, unsupplyHandler);
+                });
+            }
+        }
+
+        private Delegate _CreateSupplyHandler(User user, IReadOnlyList<Type> baseTypes, Type derivedType)
+        {
+            var parameter = Expression.Parameter(derivedType, "value");
+            var call = Expression.Call(
+                Expression.Constant(this),
+                typeof(GatewayHostClientAgentPool).GetMethod(nameof(_HandleDerivedSupply), BindingFlags.NonPublic | BindingFlags.Instance)!,
+                Expression.Constant(user),
+                Expression.Constant(baseTypes),
+                Expression.Convert(parameter, typeof(object)));
+            var handlerType = typeof(Action<>).MakeGenericType(derivedType);
+            return Expression.Lambda(handlerType, call, parameter).Compile();
+        }
+
+        private Delegate _CreateUnsupplyHandler(User user, IReadOnlyList<Type> baseTypes, Type derivedType)
+        {
+            var parameter = Expression.Parameter(derivedType, "value");
+            var call = Expression.Call(
+                Expression.Constant(this),
+                typeof(GatewayHostClientAgentPool).GetMethod(nameof(_HandleDerivedUnsupply), BindingFlags.NonPublic | BindingFlags.Instance)!,
+                Expression.Constant(user),
+                Expression.Constant(baseTypes),
+                Expression.Convert(parameter, typeof(object)));
+            var handlerType = typeof(Action<>).MakeGenericType(derivedType);
+            return Expression.Lambda(handlerType, call, parameter).Compile();
+        }
+
+        private void _HandleDerivedSupply(User user, IReadOnlyList<Type> baseTypes, object instance)
+        {
+            if (!(instance is IGhost ghost))
+            {
+                return;
+            }
+
+            foreach (var baseType in baseTypes)
+            {
+                if (!_TryTrackGhost(user, baseType, ghost.GetID()))
+                {
+                    continue;
+                }
+
+                var baseNotifier = _InvokeQueryNotifier(user.Agent, baseType);
+                if (baseNotifier is IProvider provider)
+                {
+                    provider.Add(ghost);
+                    provider.Ready(ghost.GetID());
+                }
+            }
+        }
+
+        private void _HandleDerivedUnsupply(User user, IReadOnlyList<Type> baseTypes, object instance)
+        {
+            if (!(instance is IGhost ghost))
+            {
+                return;
+            }
+
+            foreach (var baseType in baseTypes)
+            {
+                if (!_TryUntrackGhost(user, baseType, ghost.GetID()))
+                {
+                    continue;
+                }
+
+                var baseNotifier = _InvokeQueryNotifier(user.Agent, baseType);
+                if (baseNotifier is IProvider provider)
+                {
+                    provider.Remove(ghost.GetID());
+                }
+            }
+        }
+
+        private object _InvokeQueryNotifier(IAgent agent, Type interfaceType)
+        {
+            return _queryNotifierMethod.MakeGenericMethod(interfaceType).Invoke(agent, null);
+        }
+
+        private bool _TryTrackGhost(User user, Type baseType, long id)
+        {
+            if (!user.BridgedGhosts.TryGetValue(baseType, out var ids))
+            {
+                ids = new HashSet<long>();
+                user.BridgedGhosts[baseType] = ids;
+            }
+
+            return ids.Add(id);
+        }
+
+        private bool _TryUntrackGhost(User user, Type baseType, long id)
+        {
+            if (!user.BridgedGhosts.TryGetValue(baseType, out var ids))
+            {
+                return false;
+            }
+
+            return ids.Remove(id);
+        }
+
+        private void _RemoveBridgedGhosts(User user)
+        {
+            foreach (var kvp in user.BridgedGhosts)
+            {
+                var baseNotifier = _InvokeQueryNotifier(user.Agent, kvp.Key);
+                if (!(baseNotifier is IProvider provider))
+                {
+                    continue;
+                }
+
+                foreach (var id in kvp.Value.ToList())
+                {
+                    provider.Remove(id);
+                }
+            }
+
+            user.BridgedGhosts.Clear();
+        }
+
+        private void _DetachHandlers(User user)
+        {
+            if (user.DetachHandlers == null)
+            {
+                return;
+            }
+
+            foreach (var detach in user.DetachHandlers)
+            {
+                detach();
+            }
+
+            user.DetachHandlers.Clear();
+        }
+
+        private void _StartPump(User user)
+        {
+            var cts = new CancellationTokenSource();
+            user.PumpCancellation = cts;
+            user.PumpTask = Task.Run(async () =>
+            {
+                var token = cts.Token;
+                try
+                {
+                    while (!token.IsCancellationRequested)
+                    {
+                        user.Agent.HandlePackets();
+                        user.Agent.HandleMessage();
+                        await Task.Delay(1, token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+            }, cts.Token);
+        }
+
+        private void _StopPump(User user)
+        {
+            if (user.PumpCancellation == null)
+            {
+                return;
+            }
+
+            try
+            {
+                user.PumpCancellation.Cancel();
+                user.PumpTask?.Wait();
+            }
+            catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
+            {
+            }
+            finally
+            {
+                user.PumpCancellation.Dispose();
+                user.PumpCancellation = null;
+                user.PumpTask = null;
+            }
+        }
+
+        private void _RemoveUser(User user)
+        {
+            Agents.Collection.Remove(user.Agent);
+            _StopPump(user);
+            _RemoveBridgedGhosts(user);
+            _DetachHandlers(user);
+            user.Agent.Disable();
+            user.Stream?.Dispose();
         }
     }
 }

--- a/PinionCore.Remote.Gateway/Servers/GatewayServerClientChannelRegistry.cs
+++ b/PinionCore.Remote.Gateway/Servers/GatewayServerClientChannelRegistry.cs
@@ -73,6 +73,13 @@ namespace PinionCore.Remote.Gateway.Servers
         }
 
         private static readonly ConcurrentDictionary<uint, Bridge> _bridges = new ConcurrentDictionary<uint, Bridge>();
+        private static int _nextChannelId;
+
+        internal static uint AllocateChannelId()
+        {
+            var value = System.Threading.Interlocked.Increment(ref _nextChannelId);
+            return unchecked((uint)value);
+        }
 
         internal static void Register(uint channelId, IStreamable serverStream)
         {

--- a/PinionCore.Remote.Gateway/Servers/GatewayServerConnectionManager.cs
+++ b/PinionCore.Remote.Gateway/Servers/GatewayServerConnectionManager.cs
@@ -7,14 +7,12 @@ namespace PinionCore.Remote.Gateway.Servers
 {
     class GatewayServerConnectionManager : IGameLobby , IListenable 
     {
-        readonly IdProvider _idProvider;
         readonly System.Collections.Concurrent.ConcurrentDictionary<uint, IClientConnection> _clients = new System.Collections.Concurrent.ConcurrentDictionary<uint, IClientConnection>();
         readonly Notifier<IClientConnection> _clientNotifier;
-        
+
 
         public GatewayServerConnectionManager()
         {
-            _idProvider = new IdProvider();
             _clients = new System.Collections.Concurrent.ConcurrentDictionary<uint, IClientConnection>();
             _clientNotifier = new Notifier<IClientConnection>();
         }
@@ -52,7 +50,7 @@ namespace PinionCore.Remote.Gateway.Servers
 
         Value<uint> IGameLobby.Join()
         {
-            var id = _idProvider.Landlord.Rent();
+            var id = GatewayServerClientChannelRegistry.AllocateChannelId();
             var client = new GatewayServerClientChannel(id);
             if(!_clients.TryAdd(id, client))
             {


### PR DESCRIPTION
## Summary
- add derived-interface bridging and background pumps to `GatewayHostClientAgentPool` so base notifiers receive ghosts without duplicate loads
- assign unique gateway client channel IDs via `GatewayServerClientChannelRegistry.AllocateChannelId` and consume them in the connection manager

## Testing
- `dotnet test PinionCore.Remote.Gateway.Test/PinionCore.Remote.Gateway.Test.csproj --filter GatewayHostServiceIntegrationTest`
- `dotnet test PinionCore.Remote.Gateway.Test/PinionCore.Remote.Gateway.Test.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d216b30d58832eb6abbfd956918b43